### PR TITLE
Security: fix reported path traversal plus critical auth/authz findings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,12 @@ AUTH_PASSWORD=
 #                                         # and audit logs then fall back to the socket peer address.
 # WIDGET_ORIGIN_STRICT=false               # true = reject widget requests whose Origin is not in the
 #                                         # key's allowlist. false only logs what would be rejected.
+#                                         # Covers the chat page, the loader's public-config call and
+#                                         # the admin routes. Browser-enforced only: it stops the key
+#                                         # being embedded on another site, not scripted calls with a
+#                                         # forged/absent Origin — use RATE_LIMIT_ENABLED for those.
+#                                         # Entries are matched on scheme+host+port; list apex and www
+#                                         # separately, or use *.example.com.
 # WIDGET_LEGACY_ADMIN_KEY=false            # true = the public widget key still works on /widget/api
 #                                         # admin routes. Transitional only; keep false.
 

--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,10 @@ AUTH_PASSWORD=
 #                                         # (public embeddable widget/trial agents — auto-assigned),
 #                                         # pending (no access). Agents with NO roles set are admin-only.
 # SESSION_SECURE_COOKIE=false             # Set to true behind TLS in production
+# OAUTH_ALLOWED_DOMAINS=                   # Comma-separated email domains allowed to sign in via SSO.
+#                                         # Empty = anyone with a provider account can create a session.
+# OAUTH_ALLOWED_EMAILS=                    # Comma-separated individual emails allowed to sign in.
+# TOKEN_TTL_HOURS=24                       # Lifetime of bearer tokens from POST /auth/token.
 
 # Production Hardening
 # MATE_ENV=development                    # Set to 'production' to refuse startup on insecure
@@ -37,7 +41,12 @@ AUTH_PASSWORD=
 #                                         # Comma-separated CORS allowlist. Dashboard and widget chat
 #                                         # are same-origin; /widget/public-config stays open on its own.
 # TRUSTED_PROXY_HOSTS=*                   # Comma-separated proxy IPs to trust for X-Forwarded-*.
-#                                         # Restrict in production — "*" lets any client spoof them.
+#                                         # Restrict in production — "*" lets any client spoof them,
+#                                         # and audit logs then fall back to the socket peer address.
+# WIDGET_ORIGIN_STRICT=false               # true = reject widget requests whose Origin is not in the
+#                                         # key's allowlist. false only logs what would be rejected.
+# WIDGET_LEGACY_ADMIN_KEY=false            # true = the public widget key still works on /widget/api
+#                                         # admin routes. Transitional only; keep false.
 
 # Server Configuration
 # Agent runtime framework on port ADK_PORT: adk (Google ADK, default) or langgraph

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ coverage run -m unittest discover -s shared/test -p "test_*.py"
 coverage report
 ```
 
-Tests live in `shared/test/` — 134 tests covering agent management, tool factory, model switching, RBAC, migrations, guardrails, tracing, and more.
+Tests live in `shared/test/` — 506 tests covering agent management, tool factory, model switching, RBAC, authorization, migrations, guardrails, tracing, and more.
 
 ## Database Migrations
 
@@ -93,7 +93,11 @@ Follow PEP 8 with type hints on all function signatures. Use f-strings for forma
 | `MATE_ENV` | `development` (default) or `production`; production refuses insecure defaults |
 | `MATE_ALLOW_INSECURE_DEFAULTS` | Override the production startup checks |
 | `ALLOWED_ORIGINS` | Comma-separated CORS allowlist |
-| `TRUSTED_PROXY_HOSTS` | Proxy hosts trusted for `X-Forwarded-*` headers |
+| `TRUSTED_PROXY_HOSTS` | Proxy hosts trusted for `X-Forwarded-*` headers; audit logs only trust `X-Forwarded-For` when set |
+| `OAUTH_ALLOWED_DOMAINS` / `OAUTH_ALLOWED_EMAILS` | Restrict who may sign in via SSO (unset = anyone with a provider account) |
+| `TOKEN_TTL_HOURS` | Bearer token lifetime, default 24 |
+| `WIDGET_ORIGIN_STRICT` | Enforce (vs. only log) a widget key's origin allowlist |
+| `WIDGET_LEGACY_ADMIN_KEY` | Transitional: let the public widget key work on `/widget/api` admin routes |
 | `ADK_HOST` / `ADK_PORT` | ADK server address (default `127.0.0.1:8001`) |
 | `ARTIFACT_SERVICE` | `local_folder`, `supabase`, or `s3` |
 | `EMBEDDING_MODEL` | Embedding model for memory block semantic search (litellm format, default `gemini/gemini-embedding-001`) |

--- a/adk_main.py
+++ b/adk_main.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 from dotenv import load_dotenv
 from google.adk.artifacts.in_memory_artifact_service import InMemoryArtifactService
 from google.adk.auth.credential_service.in_memory_credential_service import InMemoryCredentialService
@@ -27,7 +27,7 @@ configure_logging()
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--session-db-url", default="sqlite:///session_db.db")
-parser.add_argument("--host", default="0.0.0.0")
+parser.add_argument("--host", default="127.0.0.1")
 parser.add_argument("--a2a", action="store_true", help="Enable A2A (Agent-to-Agent) client support")
 args = parser.parse_args()
 SESSION_DB_URL = args.session_db_url
@@ -165,6 +165,15 @@ register_custom_services()
 
 AGENT_DIR = os.path.dirname(os.path.abspath(__file__))+ "/agents"
 ALLOWED_ORIGINS = ["http://localhost", "http://localhost:8000", "*"]
+
+
+def _resolve_within_agents(*parts: Union[str, Path]) -> Path:
+    """Resolve a builder path, rejecting anything outside the agents directory."""
+    from shared.utils.path_safety import resolve_within_base
+
+    return resolve_within_base(Path.cwd() / AGENT_DIR.split('/')[-1], *parts)
+
+
 # ADK dev UI (Angular app at /dev-ui); set ADK_DEV_UI=false to serve the API only
 SERVE_WEB_INTERFACE = os.getenv("ADK_DEV_UI", "true").lower() != "false"
 
@@ -378,24 +387,26 @@ try:
         files: list[UploadFile], tmp: Optional[bool] = False
     ) -> bool:
         """Save agent files from the builder UI"""
-        base_path = Path.cwd() / AGENT_DIR.split('/')[-1]  # Get agents dir relative to cwd
         for file in files:
             if not file.filename:
                 print("❌ Agent name is missing in the input files")
                 return False
-            agent_name, filename = file.filename.split("/")
-            agent_dir = os.path.join(base_path, agent_name)
+            parts = file.filename.split("/")
+            if len(parts) != 2:
+                print(f"❌ Invalid file name in the input files: {file.filename}")
+                return False
+            agent_name, filename = parts
             try:
                 # File name format: {app_name}/{agent_name}.yaml
                 if tmp:
-                    agent_dir = os.path.join(agent_dir, "tmp/" + agent_name)
+                    agent_dir = _resolve_within_agents(agent_name, "tmp", agent_name)
+                    file_path = _resolve_within_agents(agent_dir, filename)
                     os.makedirs(agent_dir, exist_ok=True)
-                    file_path = os.path.join(agent_dir, filename)
                     with open(file_path, "wb") as buffer:
                         shutil.copyfileobj(file.file, buffer)
                 else:
-                    source_dir = os.path.join(agent_dir, "tmp/" + agent_name)
-                    destination_dir = agent_dir
+                    source_dir = _resolve_within_agents(agent_name, "tmp", agent_name)
+                    destination_dir = _resolve_within_agents(agent_name)
                     for item in os.listdir(source_dir):
                         source_item = os.path.join(source_dir, item)
                         destination_item = os.path.join(destination_dir, item)
@@ -411,9 +422,8 @@ try:
     @app.post("/builder/app/{app_name}/cancel", response_model_exclude_none=True)
     async def builder_cancel(app_name: str) -> bool:
         """Cancel builder changes for an agent"""
-        base_path = Path.cwd() / AGENT_DIR.split('/')[-1]
-        agent_dir = os.path.join(base_path, app_name)
-        destination_dir = os.path.join(agent_dir, "tmp/" + app_name)
+        agent_dir = _resolve_within_agents(app_name)
+        destination_dir = _resolve_within_agents(app_name, "tmp", app_name)
         source_dir = agent_dir
         source_items = set(os.listdir(source_dir))
         try:
@@ -452,13 +462,13 @@ try:
         tmp: Optional[bool] = False,
     ):
         """Get agent files for the builder UI"""
-        base_path = Path.cwd() / AGENT_DIR.split('/')[-1]
-        agent_dir = base_path / app_name
         if tmp:
-            agent_dir = agent_dir / "tmp" / app_name
+            agent_dir = _resolve_within_agents(app_name, "tmp", app_name)
+        else:
+            agent_dir = _resolve_within_agents(app_name)
         if not file_path:
             file_name = "root_agent.yaml"
-            root_file_path = agent_dir / file_name
+            root_file_path = _resolve_within_agents(agent_dir, file_name)
             if not root_file_path.is_file():
                 return ""
             else:
@@ -469,7 +479,7 @@ try:
                     headers={"Cache-Control": "no-store"},
                 )
         else:
-            agent_file_path = agent_dir / file_path
+            agent_file_path = _resolve_within_agents(agent_dir, file_path)
             if not agent_file_path.is_file():
                 return ""
             else:

--- a/auth_server.py
+++ b/auth_server.py
@@ -242,6 +242,12 @@ if _trusted_proxy_hosts != "*":
     _trusted_proxy_hosts = [h.strip() for h in _trusted_proxy_hosts.split(",") if h.strip()]
 app.add_middleware(ProxyHeadersMiddleware, trusted_hosts=_trusted_proxy_hosts)
 
+# Deny-by-default authorization for mutating /dashboard/api requests.  Added
+# BEFORE SessionMiddleware on purpose: add_middleware inserts at the front, so
+# the session middleware ends up outside this one and request.session is set.
+from server.dashboard_authz import DashboardAuthzMiddleware
+app.add_middleware(DashboardAuthzMiddleware)
+
 # Encrypted session cookie required by both OAuth PKCE state and the session-based
 # auth check in server/auth.py.  https_only defaults to False so local HTTP dev works;
 # set SESSION_SECURE_COOKIE=true behind TLS in production.

--- a/langgraph_main.py
+++ b/langgraph_main.py
@@ -20,7 +20,7 @@ configure_logging()
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--session-db-url", default="sqlite:///session_db.db")
-parser.add_argument("--host", default="0.0.0.0")
+parser.add_argument("--host", default="127.0.0.1")
 parser.add_argument("--a2a", action="store_true", help="Accepted for launch-contract parity; A2A is not supported by the langgraph runtime")
 args = parser.parse_args()
 SESSION_DB_URL = args.session_db_url

--- a/server/auth.py
+++ b/server/auth.py
@@ -13,6 +13,7 @@ Priority order for dashboard routes:
 
 import logging
 import base64
+import secrets
 from urllib.parse import quote
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import HTTPBasic, HTTPBasicCredentials, HTTPBearer, HTTPAuthorizationCredentials
@@ -28,6 +29,14 @@ bearer_scheme = HTTPBearer()
 
 AUTH_USERNAME: str = ""
 AUTH_PASSWORD: str = ""
+
+
+def credentials_match(username: str, password: str) -> bool:
+    """Compare submitted credentials in constant time."""
+    return (
+        secrets.compare_digest(str(username or ""), AUTH_USERNAME) and
+        secrets.compare_digest(str(password or ""), AUTH_PASSWORD)
+    )
 
 
 def configure_auth(username: str, password: str):
@@ -78,19 +87,22 @@ def _is_session_oauth_user(request: Request) -> bool:
     - Not an OAuth session at all (basic-auth / bearer token session)
     - OAuth user whose email/user_id matches AUTH_USERNAME
     - OAuth user who has the 'admin' role in the database
+
+    display_name is deliberately NOT accepted here: it is the provider profile
+    name, which the account holder sets freely, so matching it against
+    AUTH_USERNAME (default "admin") would hand admin to anyone who renames
+    their Google/GitHub profile.  user_id and email are provider-verified.
     """
     try:
         user = request.session.get("user")
         if user and user.get("provider") in ("google", "github", "microsoft", "gitlab"):
             user_id = user.get("user_id", "")
             email = user.get("email", "")
-            display_name = user.get("display_name", "")
 
-            # Allow admin by AUTH_USERNAME match
+            # Allow admin by AUTH_USERNAME match on a provider-verified identity
             if AUTH_USERNAME and (
                 user_id == AUTH_USERNAME or
-                email == AUTH_USERNAME or
-                display_name == AUTH_USERNAME
+                email == AUTH_USERNAME
             ):
                 return False  # treat as admin
 
@@ -129,7 +141,7 @@ def verify_credentials(credentials: HTTPBasicCredentials = Depends(security)):
     login attempts.  Logged-out status only prevents automatic
     browser-sent credentials in get_auth_user / get_dashboard_auth_user.
     """
-    if credentials.username == AUTH_USERNAME and credentials.password == AUTH_PASSWORD:
+    if credentials_match(credentials.username, credentials.password):
         return credentials
     raise HTTPException(
         status_code=401,
@@ -186,7 +198,7 @@ def get_auth_user(request: Request):
                     headers={"WWW-Authenticate": 'Basic realm="MATE"'},
                 )
 
-            if username == AUTH_USERNAME and password == AUTH_PASSWORD:
+            if credentials_match(username, password):
                 return username
         except HTTPException:
             raise
@@ -238,7 +250,7 @@ def get_dashboard_auth_user(request: Request):
                 logger.debug("Dashboard auth: basic auth logged out for %s", username)
                 return None
 
-            if username == AUTH_USERNAME and password == AUTH_PASSWORD:
+            if credentials_match(username, password):
                 return username
         except Exception:
             pass

--- a/server/auth_routes.py
+++ b/server/auth_routes.py
@@ -19,7 +19,7 @@ from shared.utils.auth_utils import (
 )
 from server.auth import (
     verify_credentials, verify_bearer_token, get_auth_user,
-    AUTH_USERNAME, AUTH_PASSWORD,
+    credentials_match, AUTH_USERNAME, AUTH_PASSWORD,
 )
 
 logger = logging.getLogger(__name__)
@@ -39,6 +39,7 @@ async def login_page(request: Request):
         "auth_failed": "OAuth authentication failed. Please try again.",
         "profile_fetch_failed": "Could not retrieve your profile from the provider.",
         "provider_not_configured": "That sign-in provider is not configured.",
+        "not_allowed": "This account is not allowed to sign in. Contact your administrator.",
         "unknown_provider": "Unknown OAuth provider.",
     }
     error_key = request.query_params.get("error", "")
@@ -124,7 +125,7 @@ async def logout(request: Request):
             encoded_credentials = auth_header[6:]
             decoded_credentials = base64.b64decode(encoded_credentials).decode("utf-8")
             u, p = decoded_credentials.split(":", 1)
-            if u == AUTH_USERNAME and p == AUTH_PASSWORD:
+            if credentials_match(u, p):
                 logger.debug("Logout: logging out basic auth for %s", u)
                 logout_basic_auth(u, p)
                 username = username or u
@@ -143,7 +144,7 @@ async def logout(request: Request):
         if not username and "username" in body and "password" in body:
             u = body["username"]
             p = body["password"]
-            if u == AUTH_USERNAME and p == AUTH_PASSWORD:
+            if credentials_match(u, p):
                 logger.debug("Logout: logging out basic auth from body for %s", u)
                 logout_basic_auth(u, p)
                 username = username or u

--- a/server/dashboard_authz.py
+++ b/server/dashboard_authz.py
@@ -1,0 +1,68 @@
+"""
+Deny-by-default authorization for dashboard write APIs.
+
+Dashboard *pages* check `is_admin_user` and redirect non-admins to the Work Room,
+but the JSON APIs behind them were authenticated-only: any signed-in user could
+call POST /dashboard/api/users with roles=["admin"] and promote themselves.
+
+This middleware requires admin for every state-changing request to
+/dashboard/api/*, except the paths in USER_WRITABLE_PATHS.  New routes are
+protected automatically — add them here only after deciding a non-admin may
+call them.
+"""
+
+import logging
+import re
+from typing import Callable
+
+from fastapi import Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
+
+logger = logging.getLogger(__name__)
+
+WRITE_METHODS = {"POST", "PUT", "DELETE", "PATCH"}
+
+PROTECTED_PREFIX = "/dashboard/api/"
+
+# Routes a non-admin (regular SSO user) may write to. Work Room is the non-admin
+# space and renaming a conversation is its only write.
+USER_WRITABLE_PATHS = [
+    re.compile(r"^/dashboard/api/workroom/title/?$"),
+]
+
+
+def _is_user_writable(path: str) -> bool:
+    return any(p.match(path) for p in USER_WRITABLE_PATHS)
+
+
+class DashboardAuthzMiddleware(BaseHTTPMiddleware):
+    """Require admin for mutating /dashboard/api requests."""
+
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:
+        path = request.url.path
+        if (
+            request.method not in WRITE_METHODS
+            or not path.startswith(PROTECTED_PREFIX)
+            or _is_user_writable(path)
+        ):
+            return await call_next(request)
+
+        from server.auth import is_admin_user
+
+        if is_admin_user(request):
+            return await call_next(request)
+
+        from server.auth import get_dashboard_auth_user
+        actor = get_dashboard_auth_user(request) or "anonymous"
+        logger.warning("Dashboard authz: denied %s %s for non-admin %s", request.method, path, actor)
+        try:
+            from shared.utils import audit_service
+            audit_service.log(
+                actor, audit_service.ACTION_RBAC_DENIAL, "dashboard_api",
+                resource_id=path, details={"method": request.method}, request=request,
+            )
+        except Exception as exc:
+            logger.debug("Audit log for denied dashboard write failed: %s", exc)
+
+        return JSONResponse({"detail": "Admin access required"}, status_code=403)

--- a/server/oauth_routes.py
+++ b/server/oauth_routes.py
@@ -71,6 +71,32 @@ def _get_oauth():
     return _oauth
 
 
+def _safe_next(next_url: str) -> str:
+    """Keep post-login redirects on this site (blocks //evil.com and absolute URLs)."""
+    if not next_url or not next_url.startswith("/") or next_url.startswith("//"):
+        return "/dashboard"
+    return next_url
+
+
+def _signup_allowed(email: str) -> bool:
+    """Check an OAuth identity against the optional signup allowlists.
+
+    Both env vars are unset by default, which keeps signup open as before.
+    OAUTH_ALLOWED_DOMAINS / OAUTH_ALLOWED_EMAILS are comma-separated.
+    """
+    domains = [d.strip().lower().lstrip("@") for d in _cfg("OAUTH_ALLOWED_DOMAINS").split(",") if d.strip()]
+    emails = [e.strip().lower() for e in _cfg("OAUTH_ALLOWED_EMAILS").split(",") if e.strip()]
+    if not domains and not emails:
+        return True
+
+    email = (email or "").lower()
+    if email and email in emails:
+        return True
+    if email and "@" in email and email.split("@", 1)[1] in domains:
+        return True
+    return False
+
+
 def _upsert_oauth_user(user_id: str, email: str, display_name: str, provider: str) -> None:
     """Create or update the users table row for an OAuth login."""
     from shared.utils.database_client import get_database_client
@@ -179,6 +205,10 @@ async def oauth_callback(provider: str, request: Request):
         logger.error("Failed to fetch OAuth profile (%s): %s", provider, exc)
         return RedirectResponse(url="/login?error=profile_fetch_failed")
 
+    if not _signup_allowed(email):
+        logger.warning("OAuth login rejected by allowlist: %s (%s)", email or user_id, provider)
+        return RedirectResponse(url="/login?error=not_allowed")
+
     _upsert_oauth_user(user_id, email, display_name, provider)
 
     request.session["user"] = {
@@ -194,5 +224,5 @@ async def oauth_callback(provider: str, request: Request):
     except Exception:
         pass
 
-    next_url = request.session.pop("oauth_next", "/dashboard")
+    next_url = _safe_next(request.session.pop("oauth_next", "/dashboard"))
     return RedirectResponse(url=next_url)

--- a/server/proxy_routes.py
+++ b/server/proxy_routes.py
@@ -233,6 +233,13 @@ async def proxy_adk(request: Request, path: str, username: str = Depends(get_aut
     if path.startswith("dashboard/"):
         raise HTTPException(status_code=404, detail="Not found")
 
+    # Builder endpoints read and write files in the agents directory: admins only.
+    # Covers both MATE's /builder/* and ADK's own /dev/apps/{app}/builder*.
+    if "builder" in path.split("/"):
+        from server.auth import is_admin_user
+        if not is_admin_user(request):
+            raise HTTPException(status_code=403, detail="Admin access required")
+
     target_url = f"http://{ADK_HOST}:{ADK_PORT}/{path}"
     body = await request.body() if request.method in ["POST", "PUT", "PATCH"] else None
 

--- a/server/widget_routes.py
+++ b/server/widget_routes.py
@@ -331,9 +331,12 @@ async def widget_admin_page(request: Request, key: str = Query(...)):
         wk = _lookup_widget_key(key)
     if wk is None:
         return HTMLResponse("<h3>Invalid widget admin key</h3>", status_code=401)
+    # Two distinct keys on this page: admin_key authorises the /widget/api calls,
+    # api_key is the public one the embedded preview widget needs.
     return templates.TemplateResponse(request, "widget/admin.html", {
         "request": request,
-        "api_key": key,
+        "admin_key": wk.admin_key or key,
+        "api_key": wk.api_key,
         "agent_name": wk.agent_name,
         "project_id": wk.project_id,
     })

--- a/server/widget_routes.py
+++ b/server/widget_routes.py
@@ -17,6 +17,7 @@ import secrets
 import tempfile
 from pathlib import Path
 from typing import Optional
+from urllib.parse import urlparse
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request, File, Form, UploadFile, Query
@@ -27,6 +28,12 @@ from shared.utils.database_client import get_database_client
 from shared.utils.models import WidgetApiKey, AgentConfig, Project
 
 logger = logging.getLogger(__name__)
+
+# Reject origins that do not match a key's allowlist. Off by default so operators
+# can see what would be rejected (logged) before enforcing.
+ORIGIN_STRICT = os.getenv("WIDGET_ORIGIN_STRICT", "false").lower() in ("true", "1", "yes")
+# Transitional: let the public api_key still authorise the /widget/api admin routes.
+LEGACY_ADMIN_KEY = os.getenv("WIDGET_LEGACY_ADMIN_KEY", "false").lower() in ("true", "1", "yes")
 
 router = APIRouter(prefix="/widget", tags=["Widget"])
 admin_api_router = APIRouter(prefix="/widget/api", tags=["Widget - Admin API"])
@@ -143,6 +150,17 @@ def _lookup_widget_key(api_key: str) -> Optional[WidgetApiKey]:
         session.close()
 
 
+def _lookup_widget_admin_key(admin_key: str) -> Optional[WidgetApiKey]:
+    db = get_database_client()
+    session = db.get_session()
+    if not session:
+        return None
+    try:
+        return session.query(WidgetApiKey).filter_by(admin_key=admin_key, is_active=True).first()
+    finally:
+        session.close()
+
+
 def _extract_api_key(request: Request) -> str:
     key = request.headers.get("X-Widget-Key") or request.query_params.get("key")
     if not key:
@@ -150,31 +168,105 @@ def _extract_api_key(request: Request) -> str:
     return key
 
 
-def _check_origin(request: Request, widget_key: WidgetApiKey):
+def _origin_host(value: str) -> Optional[tuple]:
+    """Return (scheme, host, port) for an origin or referer URL, or None."""
+    try:
+        parsed = urlparse(value.strip())
+    except ValueError:
+        return None
+    if not parsed.scheme or not parsed.hostname:
+        return None
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    return (parsed.scheme.lower(), parsed.hostname.lower(), port)
+
+
+def _origin_matches(origin: str, allowed_entry: str) -> bool:
+    """Exact scheme+host+port match, with optional *.domain wildcards.
+
+    Prefix matching would let https://victim.com.evil.com pass an allowlist
+    entry of https://victim.com, so hosts are compared as whole labels.
+    """
+    got = _origin_host(origin)
+    if got is None:
+        return False
+
+    entry = allowed_entry.strip().rstrip("/")
+    if entry.startswith("*."):  # bare wildcard domain, e.g. *.example.com
+        suffix = entry[1:].lower()  # ".example.com"
+        return got[1] == suffix[1:] or got[1].endswith(suffix)
+
+    want = _origin_host(entry)
+    if want is None:
+        return False
+    if want[1].startswith("*."):
+        suffix = want[1][1:]
+        host_ok = got[1] == suffix[1:] or got[1].endswith(suffix)
+    else:
+        host_ok = got[1] == want[1]
+    return host_ok and got[0] == want[0] and got[2] == want[2]
+
+
+def _check_origin(request: Request, widget_key: WidgetApiKey, require_origin: bool = False):
     allowed = widget_key.get_allowed_origins()
-    if allowed is None:
-        return
     origin = request.headers.get("origin") or request.headers.get("referer", "")
-    if not origin:
-        return
+
     # Always allow requests originating from the MATE server itself (e.g. admin panel preview)
-    server_origin = str(request.base_url).rstrip("/")
-    if origin.rstrip("/").startswith(server_origin):
+    if origin and _origin_matches(origin, str(request.base_url)):
         return
-    origin_normalised = origin.rstrip("/")
-    for allowed_origin in allowed:
-        if origin_normalised.startswith(allowed_origin.rstrip("/")):
-            return
+
+    if allowed is None:
+        if require_origin and not origin:
+            raise HTTPException(status_code=403, detail="Origin required for this request")
+        return
+
+    if not origin:
+        if require_origin:
+            raise HTTPException(status_code=403, detail="Origin required for this request")
+        return
+
+    if any(_origin_matches(origin, entry) for entry in allowed):
+        return
+
+    if not ORIGIN_STRICT:
+        logger.warning(
+            "Widget origin %s does not match the allowlist for key id=%s; allowed because "
+            "WIDGET_ORIGIN_STRICT is off", origin, widget_key.id,
+        )
+        return
     raise HTTPException(status_code=403, detail="Origin not allowed for this widget key")
 
 
 def verify_widget_key(request: Request) -> WidgetApiKey:
-    """FastAPI dependency: validate widget API key and origin."""
+    """FastAPI dependency: validate the public widget key and origin."""
     api_key = _extract_api_key(request)
     wk = _lookup_widget_key(api_key)
     if wk is None:
         raise HTTPException(status_code=401, detail="Invalid or inactive widget API key")
     _check_origin(request, wk)
+    return wk
+
+
+def verify_widget_admin_key(request: Request) -> WidgetApiKey:
+    """FastAPI dependency for widget management routes.
+
+    The public api_key is embedded in customer pages, so it must not authorise
+    reading the agent config or changing instruction/model/memory/files. Those
+    routes require the separate admin_key.
+    """
+    key = _extract_api_key(request)
+    wk = _lookup_widget_admin_key(key)
+
+    if wk is None and LEGACY_ADMIN_KEY:
+        wk = _lookup_widget_key(key)
+        if wk is not None:
+            logger.warning(
+                "Widget admin route accessed with the public key for key id=%s; allowed because "
+                "WIDGET_LEGACY_ADMIN_KEY is on", wk.id,
+            )
+
+    if wk is None:
+        raise HTTPException(status_code=401, detail="Invalid or inactive widget admin key")
+    _check_origin(request, wk, require_origin=False)
     return wk
 
 
@@ -233,10 +325,12 @@ async def widget_public_config(key: str = Query(...)):
 
 @router.get("/admin", response_class=HTMLResponse, include_in_schema=False)
 async def widget_admin_page(request: Request, key: str = Query(...)):
-    """Serve the widget admin panel page."""
-    wk = _lookup_widget_key(key)
+    """Serve the widget admin panel page (requires the admin key, not the public one)."""
+    wk = _lookup_widget_admin_key(key)
+    if wk is None and LEGACY_ADMIN_KEY:
+        wk = _lookup_widget_key(key)
     if wk is None:
-        return HTMLResponse("<h3>Invalid widget key</h3>", status_code=401)
+        return HTMLResponse("<h3>Invalid widget admin key</h3>", status_code=401)
     return templates.TemplateResponse(request, "widget/admin.html", {
         "request": request,
         "api_key": key,
@@ -450,13 +544,18 @@ _ALLOWED_WIDGET_CONFIG_FIELDS = {
 
 
 @admin_api_router.get("/widget-config")
-async def get_widget_config_admin(wk: WidgetApiKey = Depends(verify_widget_key)):
-    """Return the full widget_config for this key."""
+async def get_widget_config_admin(wk: WidgetApiKey = Depends(verify_widget_admin_key)):
+    """Return the full widget_config for this key.
+
+    The public chat widget reads its appearance from /widget/api/config and
+    /widget/public-config; this route is for the admin panel and the wizard's
+    appearance editor, both of which hold the admin key.
+    """
     return {"success": True, "widget_config": wk.get_widget_config()}
 
 
 @admin_api_router.put("/widget-config")
-async def update_widget_config(request: Request, wk: WidgetApiKey = Depends(verify_widget_key)):
+async def update_widget_config(request: Request, wk: WidgetApiKey = Depends(verify_widget_admin_key)):
     """Update allowed widget appearance/behaviour fields."""
     data = await request.json()
     db = get_database_client()
@@ -487,8 +586,26 @@ async def update_widget_config(request: Request, wk: WidgetApiKey = Depends(veri
 # Widget Admin API — agent settings
 # ---------------------------------------------------------------------------
 
+def _widget_agent_view(agent: AgentConfig) -> dict:
+    """Only the fields the widget admin UI edits.
+
+    Never return mcp_servers_config / tool_config / guardrail_config here —
+    MCP server definitions carry credentials.
+    """
+    return {
+        "id": agent.id,
+        "name": agent.name,
+        "type": agent.type,
+        "model_name": agent.model_name,
+        "description": agent.description,
+        "instruction": agent.instruction,
+        "disabled": agent.disabled,
+        "project_id": agent.project_id,
+    }
+
+
 @admin_api_router.get("/agent")
-async def get_widget_agent(wk: WidgetApiKey = Depends(verify_widget_key)):
+async def get_widget_agent(wk: WidgetApiKey = Depends(verify_widget_admin_key)):
     """Get the agent config scoped to this widget key."""
     db = get_database_client()
     session = db.get_session()
@@ -500,13 +617,13 @@ async def get_widget_agent(wk: WidgetApiKey = Depends(verify_widget_key)):
         ).first()
         if not agent:
             raise HTTPException(status_code=404, detail="Agent not found")
-        return {"success": True, "agent": agent.to_dict()}
+        return {"success": True, "agent": _widget_agent_view(agent)}
     finally:
         session.close()
 
 
 @admin_api_router.put("/agent")
-async def update_widget_agent(request: Request, wk: WidgetApiKey = Depends(verify_widget_key)):
+async def update_widget_agent(request: Request, wk: WidgetApiKey = Depends(verify_widget_admin_key)):
     """Update limited agent fields (instruction, model_name, description)."""
     data = await request.json()
     db = get_database_client()
@@ -523,10 +640,14 @@ async def update_widget_agent(request: Request, wk: WidgetApiKey = Depends(verif
             if field in data:
                 setattr(agent, field, data[field])
         session.commit()
-        return {"success": True, "agent": agent.to_dict()}
-    except Exception as e:
+        return {"success": True, "agent": _widget_agent_view(agent)}
+    except HTTPException:
         session.rollback()
-        raise HTTPException(status_code=500, detail=str(e))
+        raise
+    except Exception:
+        session.rollback()
+        logger.exception("Failed to update agent for widget key id=%s", wk.id)
+        raise HTTPException(status_code=500, detail="Failed to update agent")
     finally:
         session.close()
 
@@ -537,7 +658,7 @@ async def update_widget_agent(request: Request, wk: WidgetApiKey = Depends(verif
 
 @admin_api_router.get("/memory-blocks")
 async def list_widget_memory_blocks(
-    wk: WidgetApiKey = Depends(verify_widget_key),
+    wk: WidgetApiKey = Depends(verify_widget_admin_key),
     label_search: Optional[str] = None,
     value_search: Optional[str] = None,
 ):
@@ -554,7 +675,7 @@ async def list_widget_memory_blocks(
 
 
 @admin_api_router.post("/memory-blocks")
-async def create_widget_memory_block(request: Request, wk: WidgetApiKey = Depends(verify_widget_key)):
+async def create_widget_memory_block(request: Request, wk: WidgetApiKey = Depends(verify_widget_admin_key)):
     data = await request.json()
     from shared.utils.memory_blocks_service import MemoryBlocksService
     db = get_database_client()
@@ -578,7 +699,7 @@ async def create_widget_memory_block(request: Request, wk: WidgetApiKey = Depend
 
 @admin_api_router.put("/memory-blocks/{block_id}")
 async def update_widget_memory_block(
-    block_id: str, request: Request, wk: WidgetApiKey = Depends(verify_widget_key)
+    block_id: str, request: Request, wk: WidgetApiKey = Depends(verify_widget_admin_key)
 ):
     data = await request.json()
     from shared.utils.memory_blocks_service import MemoryBlocksService
@@ -596,7 +717,7 @@ async def update_widget_memory_block(
 
 
 @admin_api_router.delete("/memory-blocks/{block_id}")
-async def delete_widget_memory_block(block_id: str, wk: WidgetApiKey = Depends(verify_widget_key)):
+async def delete_widget_memory_block(block_id: str, wk: WidgetApiKey = Depends(verify_widget_admin_key)):
     from shared.utils.memory_blocks_service import MemoryBlocksService
     db = get_database_client()
     svc = MemoryBlocksService(db)
@@ -611,7 +732,7 @@ async def delete_widget_memory_block(block_id: str, wk: WidgetApiKey = Depends(v
 # ---------------------------------------------------------------------------
 
 @admin_api_router.get("/files")
-async def list_widget_files(wk: WidgetApiKey = Depends(verify_widget_key)):
+async def list_widget_files(wk: WidgetApiKey = Depends(verify_widget_admin_key)):
     """List file search stores and their files for this widget's agent."""
     from shared.utils.file_search_service import FileSearchService
     db = get_database_client()
@@ -626,7 +747,7 @@ async def list_widget_files(wk: WidgetApiKey = Depends(verify_widget_key)):
 
 @admin_api_router.post("/files/upload")
 async def upload_widget_file(
-    wk: WidgetApiKey = Depends(verify_widget_key),
+    wk: WidgetApiKey = Depends(verify_widget_admin_key),
     file: UploadFile = File(...),
     store_name: str = Form(...),
     display_name: str = Form(None),
@@ -663,7 +784,7 @@ async def upload_widget_file(
 
 
 @admin_api_router.delete("/files/{file_id}")
-async def delete_widget_file(file_id: int, wk: WidgetApiKey = Depends(verify_widget_key)):
+async def delete_widget_file(file_id: int, wk: WidgetApiKey = Depends(verify_widget_admin_key)):
     """Delete a file from a file search store."""
     from shared.utils.models import FileSearchDocument, FileSearchStore
     db = get_database_client()
@@ -734,6 +855,7 @@ async def create_widget_key(
         raise HTTPException(status_code=400, detail="project_id and agent_name are required")
 
     api_key = f"wk_{secrets.token_urlsafe(32)}"
+    admin_key = f"wak_{secrets.token_urlsafe(32)}"
 
     db = get_database_client()
     session = db.get_session()
@@ -742,6 +864,7 @@ async def create_widget_key(
     try:
         wk = WidgetApiKey(
             api_key=api_key,
+            admin_key=admin_key,
             project_id=project_id,
             agent_name=agent_name,
             label=label,
@@ -862,7 +985,12 @@ async def get_embed_code(
             f'  data-server="{base_url}"\n'
             f'></script>'
         )
-        return {"success": True, "embed_code": embed_code, "api_key": wk.api_key}
+        return {
+            "success": True,
+            "embed_code": embed_code,
+            "api_key": wk.api_key,
+            "admin_key": wk.admin_key,
+        }
     finally:
         session.close()
 

--- a/server/widget_routes.py
+++ b/server/widget_routes.py
@@ -290,10 +290,22 @@ async def serve_widget_js():
 
 @router.get("/chat", response_class=HTMLResponse, include_in_schema=False)
 async def widget_chat_page(request: Request, key: str = Query(...)):
-    """Serve the lightweight chat page (loaded inside an iframe)."""
+    """Serve the lightweight chat page (loaded inside an iframe).
+
+    This is where the embedding site is visible: the iframe navigation carries
+    the parent page as Referer. Once the page is loaded its own API calls are
+    same-origin, so the allowlist can only be enforced here and on
+    /widget/public-config, not on /widget/api/chat.
+    """
     wk = _lookup_widget_key(key)
     if wk is None:
         return HTMLResponse("<h3>Invalid widget key</h3>", status_code=401)
+    try:
+        _check_origin(request, wk)
+    except HTTPException:
+        return HTMLResponse(
+            "<h3>This chat widget is not enabled for this site.</h3>", status_code=403
+        )
     widget_cfg = wk.get_widget_config()
     return templates.TemplateResponse(request, "widget/chat.html", {
         "request": request,
@@ -304,11 +316,17 @@ async def widget_chat_page(request: Request, key: str = Query(...)):
 
 
 @router.get("/public-config", include_in_schema=False)
-async def widget_public_config(key: str = Query(...)):
-    """Return lightweight appearance config (button_color, theme) without full auth."""
+async def widget_public_config(request: Request, key: str = Query(...)):
+    """Return lightweight appearance config (button_color, theme) without full auth.
+
+    The loader calls this from the embedding page, so the browser sends a
+    truthful Origin header — the most reliable allowlist check available for
+    the chat surface.
+    """
     wk = _lookup_widget_key(key)
     if wk is None:
         raise HTTPException(status_code=401, detail="Invalid widget key")
+    _check_origin(request, wk)
     cfg = wk.get_widget_config()
     # The widget loader calls this from the embedding site's origin, so it needs a
     # permissive CORS header of its own now that the app-wide policy is restricted.

--- a/server/wizard_routes.py
+++ b/server/wizard_routes.py
@@ -108,6 +108,23 @@ def _verify_captcha(token: Optional[str]) -> bool:
     return bool(token)
 
 
+def _admin_key_for(api_key: Optional[str]) -> Optional[str]:
+    """Resolve a trial's widget admin key so the wizard can edit its appearance."""
+    if not api_key:
+        return None
+    from shared.utils.models import WidgetApiKey
+
+    db = get_database_client()
+    session = db.get_session()
+    if not session:
+        return None
+    try:
+        wk = session.query(WidgetApiKey).filter_by(api_key=api_key).first()
+        return wk.admin_key if wk else None
+    finally:
+        session.close()
+
+
 def _get_session(token: str) -> Optional[WizardSession]:
     if not token:
         return None
@@ -207,6 +224,7 @@ async def get_session_state(token: str):
         "status": ws.status,
         "step_data": ws.get_step_data(),
         "widget_api_key": ws.widget_api_key,
+        "widget_admin_key": _admin_key_for(ws.widget_api_key),
         "chat_url": f"/widget/chat?key={ws.widget_api_key}" if ws.widget_api_key else None,
         "root_agent_name": ws.root_agent_name,
     }
@@ -316,6 +334,7 @@ async def provision(request: Request):
             # Already provisioned — return existing trial (idempotent).
             return {
                 "widget_api_key": ws.widget_api_key,
+                "widget_admin_key": _admin_key_for(ws.widget_api_key),
                 "chat_url": f"/widget/chat?key={ws.widget_api_key}",
                 "project_id": ws.trial_project_id,
                 "root_agent_name": ws.root_agent_name,

--- a/shared/sql/migrations/mysql/V025__widget_admin_key.sql
+++ b/shared/sql/migrations/mysql/V025__widget_admin_key.sql
@@ -1,0 +1,14 @@
+-- Migration: Separate admin key for widget management endpoints
+-- Version: V025
+-- Database: MySQL
+--
+-- The embeddable api_key is public by design; it must not also authorise the
+-- /widget/api admin routes. Existing rows get a generated admin key.
+
+ALTER TABLE widget_api_keys ADD COLUMN admin_key VARCHAR(255);
+
+UPDATE widget_api_keys
+SET admin_key = CONCAT('wak_', SHA2(CONCAT(RAND(), UUID(), id), 256))
+WHERE admin_key IS NULL;
+
+CREATE UNIQUE INDEX ix_widget_api_keys_admin_key ON widget_api_keys (admin_key);

--- a/shared/sql/migrations/postgresql/V025__widget_admin_key.sql
+++ b/shared/sql/migrations/postgresql/V025__widget_admin_key.sql
@@ -1,0 +1,16 @@
+-- Migration: Separate admin key for widget management endpoints
+-- Version: V025
+-- Database: PostgreSQL
+--
+-- The embeddable api_key is public by design; it must not also authorise the
+-- /widget/api admin routes. Existing rows get a generated admin key.
+
+ALTER TABLE widget_api_keys ADD COLUMN IF NOT EXISTS admin_key VARCHAR(255);
+
+UPDATE widget_api_keys
+SET admin_key = 'wak_' || md5(random()::text || clock_timestamp()::text || id::text)
+                       || md5(random()::text || id::text)
+WHERE admin_key IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ix_widget_api_keys_admin_key
+    ON widget_api_keys (admin_key);

--- a/shared/sql/migrations/sqlite/V025__widget_admin_key.sql
+++ b/shared/sql/migrations/sqlite/V025__widget_admin_key.sql
@@ -1,0 +1,15 @@
+-- Migration: Separate admin key for widget management endpoints
+-- Version: V025
+-- Database: SQLite
+--
+-- The embeddable api_key is public by design; it must not also authorise the
+-- /widget/api admin routes. Existing rows get a generated admin key.
+
+ALTER TABLE widget_api_keys ADD COLUMN admin_key TEXT;
+
+UPDATE widget_api_keys
+SET admin_key = 'wak_' || lower(hex(randomblob(24)))
+WHERE admin_key IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ix_widget_api_keys_admin_key
+    ON widget_api_keys (admin_key);

--- a/shared/test/test_audit_log_hardening.py
+++ b/shared/test/test_audit_log_hardening.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""
+Tests for the audit-log hardening.
+
+The audit page concatenated actor/action/resource/ip/details straight into
+innerHTML, and ip_address came from a raw X-Forwarded-For header — so an
+unauthenticated request could store script that ran in an admin's browser.
+"""
+
+import unittest
+from unittest.mock import patch
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from shared.utils.audit_service import _client_ip
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+AUDIT_TEMPLATE = os.path.join(REPO_ROOT, "templates", "dashboard", "audit_logs.html")
+
+
+class _Client:
+    def __init__(self, host):
+        self.host = host
+
+
+class _Req:
+    def __init__(self, headers=None, host="10.0.0.9"):
+        self.headers = headers or {}
+        self.client = _Client(host)
+
+
+class TestClientIp(unittest.TestCase):
+
+    def test_forwarded_header_ignored_by_default(self):
+        req = _Req({"X-Forwarded-For": "<img src=x onerror=alert(1)>"})
+        with patch.dict(os.environ, {"TRUSTED_PROXY_HOSTS": "*"}):
+            self.assertEqual(_client_ip(req), "10.0.0.9")
+
+    def test_forwarded_header_ignored_when_unset(self):
+        req = _Req({"X-Forwarded-For": "1.2.3.4"})
+        env = {k: v for k, v in os.environ.items() if k != "TRUSTED_PROXY_HOSTS"}
+        with patch.dict(os.environ, env, clear=True):
+            self.assertEqual(_client_ip(req), "10.0.0.9")
+
+    def test_forwarded_header_used_when_proxy_configured(self):
+        req = _Req({"X-Forwarded-For": "1.2.3.4, 10.0.0.1"})
+        with patch.dict(os.environ, {"TRUSTED_PROXY_HOSTS": "10.0.0.1"}):
+            self.assertEqual(_client_ip(req), "1.2.3.4")
+
+    def test_no_request_is_none(self):
+        self.assertIsNone(_client_ip(None))
+
+
+class TestAuditTemplateEscaping(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        with open(AUDIT_TEMPLATE, encoding="utf-8") as fh:
+            cls.source = fh.read()
+
+    def test_esc_helper_defined(self):
+        self.assertIn("function esc(s)", self.source)
+        self.assertIn("&#39;", self.source, "esc() must also escape single quotes")
+
+    def test_row_fields_are_escaped(self):
+        row = self.source[self.source.index("tbody.innerHTML = logs.map"):]
+        row = row[:row.index(").join('');")]
+        for field in ("row.actor", "row.action", "row.resource_type", "row.ip_address"):
+            self.assertIn(f"esc({field}", row, f"{field} rendered unescaped")
+        self.assertNotIn("+ (row.actor", row)
+        self.assertNotIn("+ (row.ip_address", row)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/shared/test/test_builder_path_traversal.py
+++ b/shared/test/test_builder_path_traversal.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""
+Regression tests for the /builder/* path traversal fix.
+
+The builder endpoints in adk_main.py built filesystem paths straight from
+user input (``file_path`` query param, ``app_name`` path param, upload
+filenames), allowing reads and writes outside the agents directory.
+All three now route through resolve_within_base().
+
+adk_main.py cannot be imported here (it calls parse_args() and registers
+services at import time), so these tests cover the containment helper with
+the exact payloads the endpoints pass through, plus a source-level check
+that the handlers still use it.
+"""
+
+import unittest
+import re
+import sys
+import os
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from fastapi import HTTPException
+
+from shared.utils.path_safety import resolve_within_base
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AGENTS_BASE = REPO_ROOT / "agents"
+
+
+class TestResolveWithinBase(unittest.TestCase):
+    """Containment for the payloads from the report."""
+
+    def test_normal_file_allowed(self):
+        target = resolve_within_base(AGENTS_BASE, "my_agent", "root_agent.yaml")
+        self.assertEqual(target, AGENTS_BASE / "my_agent" / "root_agent.yaml")
+
+    def test_nested_file_allowed(self):
+        target = resolve_within_base(AGENTS_BASE, "my_agent", "tmp", "my_agent", "sub.yaml")
+        self.assertTrue(target.is_relative_to(AGENTS_BASE))
+
+    def test_base_itself_allowed(self):
+        self.assertEqual(resolve_within_base(AGENTS_BASE), AGENTS_BASE.resolve())
+
+    def test_dotdot_escape_rejected(self):
+        with self.assertRaises(HTTPException) as ctx:
+            resolve_within_base(AGENTS_BASE, "my_agent", "../../.env")
+        self.assertEqual(ctx.exception.status_code, 403)
+
+    def test_absolute_path_rejected(self):
+        # Path("/a/b") / "/etc/passwd" silently drops the base.
+        with self.assertRaises(HTTPException) as ctx:
+            resolve_within_base(AGENTS_BASE, "my_agent", "/etc/passwd")
+        self.assertEqual(ctx.exception.status_code, 403)
+
+    def test_absolute_app_name_rejected(self):
+        with self.assertRaises(HTTPException):
+            resolve_within_base(AGENTS_BASE, "/etc", "passwd")
+
+    def test_dotdot_app_name_rejected(self):
+        # builder_cancel / get_agent_builder: app_name = ".." reached rmtree.
+        with self.assertRaises(HTTPException):
+            resolve_within_base(AGENTS_BASE, "..")
+
+    def test_dotdot_app_name_with_tmp_rejected(self):
+        # builder_build tmp branch: agents/../tmp/.. resolved to the repo root.
+        with self.assertRaises(HTTPException):
+            resolve_within_base(AGENTS_BASE, "..", "tmp", "..")
+
+    def test_upload_filename_escape_rejected(self):
+        agent_dir = resolve_within_base(AGENTS_BASE, "my_agent", "tmp", "my_agent")
+        with self.assertRaises(HTTPException):
+            resolve_within_base(AGENTS_BASE, agent_dir, "../../../../auth_server.py")
+
+    def test_agent_folder_delete_cannot_escape(self):
+        # DELETE /dashboard/api/agents/{agent_name}/delete-folder reached rmtree.
+        with self.assertRaises(HTTPException):
+            resolve_within_base(AGENTS_BASE, "..")
+        with self.assertRaises(HTTPException):
+            resolve_within_base(AGENTS_BASE, "../..")
+
+    def test_symlink_style_sibling_rejected(self):
+        # A sibling directory sharing the base's name prefix must not pass.
+        with self.assertRaises(HTTPException):
+            resolve_within_base(AGENTS_BASE, "..", "agents_backup")
+
+
+class TestBuilderHandlersUseHelper(unittest.TestCase):
+    """The three handlers must not rebuild raw paths from user input."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.source = (REPO_ROOT / "adk_main.py").read_text()
+        cls.builder_block = cls.source[cls.source.index('@app.post("/builder/save"'):
+                                       cls.source.index("Added builder endpoints")]
+
+    def test_no_raw_joins_in_builder_block(self):
+        for bad in ("agent_dir / file_path", "agent_dir / file_name", 'os.path.join(base_path'):
+            self.assertNotIn(bad, self.builder_block, f"raw path join reintroduced: {bad}")
+
+    def test_each_handler_resolves(self):
+        for handler in ("builder_build", "builder_cancel", "get_agent_builder"):
+            start = self.builder_block.index(f"def {handler}(")
+            body = self.builder_block[start:]
+            next_decorator = body.find("@app.", 1)
+            if next_decorator != -1:
+                body = body[:next_decorator]
+            self.assertIn("_resolve_within_agents", body, f"{handler} bypasses containment")
+
+    def test_upload_filename_split_is_guarded(self):
+        # An unguarded split("/") raised ValueError -> 500 on malformed names.
+        self.assertNotRegex(self.builder_block, r'\w+,\s*\w+ = file\.filename\.split\("/"\)')
+        self.assertRegex(self.builder_block, r"len\(parts\) != 2")
+
+
+class TestBindDefaults(unittest.TestCase):
+    """SECURITY.md: the agent servers must not default to a public bind."""
+
+    def test_agent_servers_default_to_loopback(self):
+        for module in ("adk_main.py", "langgraph_main.py"):
+            source = (REPO_ROOT / module).read_text()
+            match = re.search(r'add_argument\("--host",\s*default="([^"]+)"\)', source)
+            self.assertIsNotNone(match, f"--host argument not found in {module}")
+            self.assertEqual(match.group(1), "127.0.0.1", f"{module} binds publicly by default")
+
+
+class TestBuilderProxyGate(unittest.TestCase):
+    """/builder/* is admin-only at the auth server proxy."""
+
+    def test_proxy_gates_builder_paths(self):
+        source = (REPO_ROOT / "server" / "proxy_routes.py").read_text()
+        block = source[source.index("async def proxy_adk(request"):]
+        self.assertIn('"builder" in path.split("/")', block)
+        self.assertIn("is_admin_user", block)
+
+    def test_gate_matches_both_endpoint_families(self):
+        # MATE's own /builder/* and ADK's upstream /dev/apps/{app}/builder*.
+        gated = lambda p: "builder" in p.split("/")
+        for path in ("builder/save", "builder/app/x", "builder/app/x/cancel",
+                     "dev/apps/x/builder", "dev/apps/x/builder/save"):
+            self.assertTrue(gated(path), f"{path} not gated")
+        for path in ("run_sse", "list-apps", "apps/builderbot/users/u/sessions"):
+            self.assertFalse(gated(path), f"{path} gated by mistake")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/shared/test/test_dashboard_authz.py
+++ b/shared/test/test_dashboard_authz.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""
+Tests for deny-by-default authorization on mutating /dashboard/api routes.
+
+Dashboard pages checked is_admin_user but the JSON APIs behind them did not:
+any authenticated user could POST /dashboard/api/users with roles=["admin"].
+"""
+
+import unittest
+from unittest.mock import patch
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from server.dashboard_authz import DashboardAuthzMiddleware, USER_WRITABLE_PATHS
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(DashboardAuthzMiddleware)
+
+    @app.post("/dashboard/api/users")
+    async def create_user():
+        return {"ok": True}
+
+    @app.put("/dashboard/api/agents/1")
+    async def update_agent():
+        return {"ok": True}
+
+    @app.delete("/dashboard/api/agents/x/delete-folder")
+    async def delete_folder():
+        return {"ok": True}
+
+    @app.get("/dashboard/api/users")
+    async def list_users():
+        return {"ok": True}
+
+    @app.post("/dashboard/api/workroom/title")
+    async def workroom_title():
+        return {"ok": True}
+
+    @app.post("/run_sse")
+    async def run_sse():
+        return {"ok": True}
+
+    return app
+
+
+class TestDashboardAuthz(unittest.TestCase):
+    """Writes require admin; reads and allowlisted routes do not."""
+
+    def setUp(self):
+        self.client = TestClient(_app())
+
+    def _as(self, admin: bool):
+        return patch("server.auth.is_admin_user", return_value=admin)
+
+    def test_non_admin_cannot_create_user(self):
+        with self._as(False):
+            r = self.client.post("/dashboard/api/users")
+        self.assertEqual(r.status_code, 403)
+        self.assertIn("Admin", r.json()["detail"])
+
+    def test_non_admin_cannot_write_agents(self):
+        with self._as(False):
+            self.assertEqual(self.client.put("/dashboard/api/agents/1").status_code, 403)
+            self.assertEqual(
+                self.client.delete("/dashboard/api/agents/x/delete-folder").status_code, 403
+            )
+
+    def test_admin_can_write(self):
+        with self._as(True):
+            self.assertEqual(self.client.post("/dashboard/api/users").status_code, 200)
+            self.assertEqual(self.client.put("/dashboard/api/agents/1").status_code, 200)
+
+    def test_reads_are_not_gated(self):
+        with self._as(False):
+            self.assertEqual(self.client.get("/dashboard/api/users").status_code, 200)
+
+    def test_workroom_title_allowlisted_for_users(self):
+        with self._as(False):
+            self.assertEqual(self.client.post("/dashboard/api/workroom/title").status_code, 200)
+
+    def test_non_dashboard_routes_untouched(self):
+        with self._as(False):
+            self.assertEqual(self.client.post("/run_sse").status_code, 200)
+
+    def test_allowlist_stays_small(self):
+        # Every entry here is a route a non-admin may write to; keep it deliberate.
+        self.assertEqual(len(USER_WRITABLE_PATHS), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/shared/test/test_oauth_admin_bypass.py
+++ b/shared/test/test_oauth_admin_bypass.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""
+Tests for the OAuth admin-decision fix.
+
+A session used to be treated as admin when the provider *display name* matched
+AUTH_USERNAME (default "admin"). Display names are chosen freely by the account
+holder, so renaming a GitHub profile to "admin" granted platform admin.
+Only provider-verified identities (user_id / email) or the DB role may do that.
+"""
+
+import unittest
+from unittest.mock import patch
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from server import auth as auth_module
+from server.auth import is_admin_user, get_user_role
+from server.oauth_routes import _safe_next, _signup_allowed
+
+
+class _Req:
+    """Minimal stand-in for a Starlette Request with a session."""
+
+    def __init__(self, session):
+        self.session = session
+
+
+def _oauth_session(**kwargs):
+    base = {"provider": "github", "user_id": "attacker@example.com",
+            "email": "attacker@example.com", "display_name": "Attacker"}
+    base.update(kwargs)
+    return _Req({"user": base})
+
+
+class TestOAuthAdminDecision(unittest.TestCase):
+
+    def setUp(self):
+        self._orig = auth_module.AUTH_USERNAME
+        auth_module.AUTH_USERNAME = "admin"
+        self._no_db_role = patch("server.auth._oauth_user_has_admin_role", return_value=False)
+        self._no_db_role.start()
+
+    def tearDown(self):
+        auth_module.AUTH_USERNAME = self._orig
+        self._no_db_role.stop()
+
+    def test_display_name_does_not_grant_admin(self):
+        req = _oauth_session(display_name="admin")
+        self.assertFalse(is_admin_user(req))
+        self.assertEqual(get_user_role(req), "user")
+
+    def test_regular_oauth_user_is_not_admin(self):
+        self.assertFalse(is_admin_user(_oauth_session()))
+
+    def test_verified_user_id_still_grants_admin(self):
+        self.assertTrue(is_admin_user(_oauth_session(user_id="admin")))
+
+    def test_verified_email_still_grants_admin(self):
+        self.assertTrue(is_admin_user(_oauth_session(email="admin", user_id="")))
+
+    def test_db_admin_role_grants_admin(self):
+        with patch("server.auth._oauth_user_has_admin_role", return_value=True):
+            self.assertTrue(is_admin_user(_oauth_session()))
+
+    def test_basic_auth_session_is_admin(self):
+        req = _Req({"user": {"provider": "basic", "user_id": "admin", "display_name": "admin"}})
+        self.assertTrue(is_admin_user(req))
+
+    def test_no_session_is_admin(self):
+        # Basic-auth / bearer callers have no OAuth session and stay admin.
+        self.assertTrue(is_admin_user(_Req({})))
+
+
+class TestSignupAllowlist(unittest.TestCase):
+
+    def test_open_when_unset(self):
+        with patch.dict(os.environ, {"OAUTH_ALLOWED_DOMAINS": "", "OAUTH_ALLOWED_EMAILS": ""}):
+            self.assertTrue(_signup_allowed("anyone@example.com"))
+
+    def test_domain_allowlist(self):
+        with patch.dict(os.environ, {"OAUTH_ALLOWED_DOMAINS": "corp.com", "OAUTH_ALLOWED_EMAILS": ""}):
+            self.assertTrue(_signup_allowed("dev@corp.com"))
+            self.assertFalse(_signup_allowed("dev@evil.com"))
+            self.assertFalse(_signup_allowed("dev@notcorp.com"))
+
+    def test_email_allowlist(self):
+        with patch.dict(os.environ, {"OAUTH_ALLOWED_DOMAINS": "", "OAUTH_ALLOWED_EMAILS": "boss@corp.com"}):
+            self.assertTrue(_signup_allowed("boss@corp.com"))
+            self.assertFalse(_signup_allowed("intern@corp.com"))
+
+
+class TestSafeNext(unittest.TestCase):
+
+    def test_relative_path_kept(self):
+        self.assertEqual(_safe_next("/dashboard/agents"), "/dashboard/agents")
+
+    def test_absolute_url_rejected(self):
+        self.assertEqual(_safe_next("https://evil.com"), "/dashboard")
+
+    def test_protocol_relative_rejected(self):
+        self.assertEqual(_safe_next("//evil.com"), "/dashboard")
+
+    def test_empty_falls_back(self):
+        self.assertEqual(_safe_next(""), "/dashboard")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/shared/test/test_token_expiry.py
+++ b/shared/test/test_token_expiry.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""
+Tests for bearer token expiry.
+
+Tokens from POST /auth/token were kept in an in-memory set with no TTL, so a
+leaked token stayed valid until the process restarted or it was revoked.
+"""
+
+import unittest
+from unittest.mock import patch
+from datetime import datetime, timedelta
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from shared.utils import auth_utils
+
+
+class TestTokenExpiry(unittest.TestCase):
+
+    def setUp(self):
+        auth_utils._active_tokens.clear()
+
+    def test_fresh_token_is_valid(self):
+        token = auth_utils.generate_token()
+        self.assertTrue(auth_utils.verify_token(token))
+
+    def test_expired_token_is_rejected_and_dropped(self):
+        token = auth_utils.generate_token()
+        auth_utils._active_tokens[token] = datetime.now() - timedelta(seconds=1)
+        self.assertFalse(auth_utils.verify_token(token))
+        self.assertNotIn(token, auth_utils._active_tokens)
+
+    def test_unknown_token_is_rejected(self):
+        self.assertFalse(auth_utils.verify_token("not-a-token"))
+
+    def test_revoke_still_works(self):
+        token = auth_utils.generate_token()
+        auth_utils.revoke_token(token)
+        self.assertFalse(auth_utils.verify_token(token))
+
+    def test_revoking_unknown_token_does_not_raise(self):
+        auth_utils.revoke_token("never-existed")
+
+    def test_ttl_is_configurable(self):
+        with patch.dict(os.environ, {"TOKEN_TTL_HOURS": "1"}):
+            token = auth_utils.generate_token()
+            remaining = auth_utils._active_tokens[token] - datetime.now()
+        self.assertLess(remaining, timedelta(hours=1, seconds=5))
+        self.assertGreater(remaining, timedelta(minutes=55))
+
+    def test_bad_ttl_value_falls_back_to_default(self):
+        with patch.dict(os.environ, {"TOKEN_TTL_HOURS": "not-a-number"}):
+            self.assertEqual(auth_utils._token_ttl(), timedelta(hours=24))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/shared/test/test_widget_admin_key.py
+++ b/shared/test/test_widget_admin_key.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""
+Tests for the widget key split and origin checking.
+
+The embeddable api_key is public (it sits in the customer's page source), so it
+must not authorise the /widget/api admin routes — reading the agent config,
+rewriting instruction/model, memory blocks, or file uploads. Those need the
+separate admin_key. Origin matching must also compare whole hosts, not prefixes.
+"""
+
+import unittest
+from unittest.mock import patch
+import sys
+import os
+import re
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from fastapi import HTTPException
+
+from server import widget_routes as wr
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class _Key:
+    def __init__(self, api_key="wk_public", admin_key="wak_secret", origins=None, id=1):
+        self.api_key = api_key
+        self.admin_key = admin_key
+        self.id = id
+        self._origins = origins
+
+    def get_allowed_origins(self):
+        return self._origins
+
+
+class _Req:
+    def __init__(self, headers=None, params=None, base_url="http://localhost:8000/"):
+        self.headers = headers or {}
+        self.query_params = params or {}
+        self.base_url = base_url
+
+
+def _lookups(row):
+    """Patch both lookups so only the matching secret resolves."""
+    return (
+        patch.object(wr, "_lookup_widget_key",
+                     side_effect=lambda k: row if k == row.api_key else None),
+        patch.object(wr, "_lookup_widget_admin_key",
+                     side_effect=lambda k: row if k == row.admin_key else None),
+    )
+
+
+class TestAdminKeyRequired(unittest.TestCase):
+
+    def setUp(self):
+        self.row = _Key()
+        self.p1, self.p2 = _lookups(self.row)
+        self.p1.start()
+        self.p2.start()
+        self.addCleanup(self.p1.stop)
+        self.addCleanup(self.p2.stop)
+
+    def test_public_key_rejected_on_admin_routes(self):
+        req = _Req(headers={"X-Widget-Key": "wk_public"})
+        with patch.object(wr, "LEGACY_ADMIN_KEY", False):
+            with self.assertRaises(HTTPException) as ctx:
+                wr.verify_widget_admin_key(req)
+        self.assertEqual(ctx.exception.status_code, 401)
+
+    def test_admin_key_accepted_on_admin_routes(self):
+        req = _Req(headers={"X-Widget-Key": "wak_secret"})
+        self.assertIs(wr.verify_widget_admin_key(req), self.row)
+
+    def test_public_key_still_works_for_chat(self):
+        req = _Req(headers={"X-Widget-Key": "wk_public"})
+        self.assertIs(wr.verify_widget_key(req), self.row)
+
+    def test_admin_key_does_not_open_the_public_route(self):
+        req = _Req(headers={"X-Widget-Key": "wak_secret"})
+        with self.assertRaises(HTTPException):
+            wr.verify_widget_key(req)
+
+    def test_legacy_flag_reopens_public_key(self):
+        req = _Req(headers={"X-Widget-Key": "wk_public"})
+        with patch.object(wr, "LEGACY_ADMIN_KEY", True):
+            self.assertIs(wr.verify_widget_admin_key(req), self.row)
+
+    def test_missing_key_is_401(self):
+        with self.assertRaises(HTTPException) as ctx:
+            wr.verify_widget_admin_key(_Req())
+        self.assertEqual(ctx.exception.status_code, 401)
+
+
+class TestOriginMatching(unittest.TestCase):
+
+    def test_exact_host_matches(self):
+        self.assertTrue(wr._origin_matches("https://victim.com", "https://victim.com"))
+        self.assertTrue(wr._origin_matches("https://victim.com/page", "https://victim.com"))
+
+    def test_suffix_lookalike_rejected(self):
+        # The bug: startswith() let this through.
+        self.assertFalse(wr._origin_matches("https://victim.com.evil.com", "https://victim.com"))
+
+    def test_other_host_rejected(self):
+        self.assertFalse(wr._origin_matches("https://evil.com", "https://victim.com"))
+
+    def test_scheme_must_match(self):
+        self.assertFalse(wr._origin_matches("http://victim.com", "https://victim.com"))
+
+    def test_port_must_match(self):
+        self.assertFalse(wr._origin_matches("https://victim.com:8443", "https://victim.com"))
+
+    def test_subdomain_needs_wildcard(self):
+        self.assertFalse(wr._origin_matches("https://app.victim.com", "https://victim.com"))
+        self.assertTrue(wr._origin_matches("https://app.victim.com", "*.victim.com"))
+
+    def test_garbage_origin_rejected(self):
+        self.assertFalse(wr._origin_matches("not a url", "https://victim.com"))
+
+
+class TestCheckOrigin(unittest.TestCase):
+
+    def test_allowlisted_origin_passes(self):
+        row = _Key(origins=["https://victim.com"])
+        wr._check_origin(_Req(headers={"origin": "https://victim.com"}), row)
+
+    def test_mismatch_rejected_in_strict_mode(self):
+        row = _Key(origins=["https://victim.com"])
+        with patch.object(wr, "ORIGIN_STRICT", True):
+            with self.assertRaises(HTTPException) as ctx:
+                wr._check_origin(_Req(headers={"origin": "https://victim.com.evil.com"}), row)
+        self.assertEqual(ctx.exception.status_code, 403)
+
+    def test_mismatch_only_logged_when_not_strict(self):
+        row = _Key(origins=["https://victim.com"])
+        with patch.object(wr, "ORIGIN_STRICT", False):
+            wr._check_origin(_Req(headers={"origin": "https://evil.com"}), row)
+
+    def test_server_own_origin_always_allowed(self):
+        row = _Key(origins=["https://victim.com"])
+        with patch.object(wr, "ORIGIN_STRICT", True):
+            wr._check_origin(
+                _Req(headers={"origin": "http://localhost:8000"}, base_url="http://localhost:8000/"),
+                row,
+            )
+
+    def test_missing_origin_allowed_for_chat(self):
+        # Server-side integrations call the chat API without a browser origin.
+        row = _Key(origins=["https://victim.com"])
+        with patch.object(wr, "ORIGIN_STRICT", True):
+            wr._check_origin(_Req(), row)
+
+    def test_missing_origin_can_be_required(self):
+        row = _Key(origins=["https://victim.com"])
+        with self.assertRaises(HTTPException):
+            wr._check_origin(_Req(), row, require_origin=True)
+
+
+class TestAdminRoutesWiring(unittest.TestCase):
+    """Every /widget/api admin route must depend on the admin key."""
+
+    def setUp(self):
+        with open(os.path.join(REPO_ROOT, "server", "widget_routes.py"), encoding="utf-8") as fh:
+            self.source = fh.read()
+
+    def test_no_admin_route_uses_the_public_dependency(self):
+        blocks = re.findall(
+            r'@admin_api_router\.(get|post|put|delete)\("([^"]+)"\)\s*\n(.*?)(?=\n@|\nclass |\Z)',
+            self.source, re.S,
+        )
+        self.assertGreater(len(blocks), 5, "admin routes not found — parser out of date")
+        for method, path, body in blocks:
+            self.assertIn(
+                "verify_widget_admin_key", body,
+                f"{method.upper()} {path} still accepts the public widget key",
+            )
+
+    def test_agent_response_hides_credentials(self):
+        view = self.source[self.source.index("def _widget_agent_view"):]
+        view = view[:view.index("\n\n\n")]
+        returned = view[view.index("return {"):]  # skip the docstring, check the payload
+        for leaked in ("mcp_servers_config", "tool_config", "guardrail_config"):
+            self.assertNotIn(leaked, returned, f"{leaked} exposed to widget admin callers")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/shared/test/test_widget_chat_origin.py
+++ b/shared/test/test_widget_chat_origin.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""
+Tests for the widget key origin allowlist on the chat surface.
+
+The allowlist used to guard only the admin routes. The chat page and the
+loader's public-config call are the two places where the embedding site is
+actually visible to the server — once the iframe is loaded, its API calls are
+same-origin and carry MATE's own origin, so they cannot be attributed to the
+parent site. Both are now checked.
+"""
+
+import unittest
+from unittest.mock import patch
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from server import widget_routes as wr
+
+
+class _Key:
+    def __init__(self, origins=None):
+        self.id = 1
+        self.api_key = "wk_public"
+        self.admin_key = "wak_secret"
+        self.agent_name = "test_agent"
+        self.project_id = 1
+        self._origins = origins
+
+    def get_allowed_origins(self):
+        return self._origins
+
+    def get_widget_config(self):
+        return {"greeting": "hi", "theme": "light", "button_color": "#2563eb"}
+
+
+def _client(origins):
+    app = FastAPI()
+    app.include_router(wr.router)
+    patcher = patch.object(
+        wr, "_lookup_widget_key",
+        side_effect=lambda k: _Key(origins) if k == "wk_public" else None,
+    )
+    patcher.start()
+    return TestClient(app, base_url="http://mate.local"), patcher
+
+
+class TestPublicConfigOrigin(unittest.TestCase):
+    """The loader's cross-origin call carries a browser-set Origin header."""
+
+    def setUp(self):
+        self.client, self.patcher = _client(["https://antonijevic.rs"])
+        self.addCleanup(self.patcher.stop)
+
+    def test_allowed_origin_passes(self):
+        r = self.client.get("/widget/public-config?key=wk_public",
+                            headers={"Origin": "https://antonijevic.rs"})
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.headers["access-control-allow-origin"], "*")
+
+    def test_foreign_origin_rejected_when_strict(self):
+        with patch.object(wr, "ORIGIN_STRICT", True):
+            r = self.client.get("/widget/public-config?key=wk_public",
+                                headers={"Origin": "https://evil.example"})
+        self.assertEqual(r.status_code, 403)
+
+    def test_lookalike_origin_rejected_when_strict(self):
+        with patch.object(wr, "ORIGIN_STRICT", True):
+            r = self.client.get("/widget/public-config?key=wk_public",
+                                headers={"Origin": "https://antonijevic.rs.evil.example"})
+        self.assertEqual(r.status_code, 403)
+
+    def test_foreign_origin_only_logged_when_not_strict(self):
+        with patch.object(wr, "ORIGIN_STRICT", False):
+            r = self.client.get("/widget/public-config?key=wk_public",
+                                headers={"Origin": "https://evil.example"})
+        self.assertEqual(r.status_code, 200)
+
+    def test_invalid_key_still_401(self):
+        r = self.client.get("/widget/public-config?key=nope",
+                            headers={"Origin": "https://antonijevic.rs"})
+        self.assertEqual(r.status_code, 401)
+
+
+class TestChatPageOrigin(unittest.TestCase):
+    """The iframe navigation carries the parent page as Referer."""
+
+    def setUp(self):
+        self.client, self.patcher = _client(["https://antonijevic.rs"])
+        self.addCleanup(self.patcher.stop)
+
+    def test_allowed_parent_passes(self):
+        r = self.client.get("/widget/chat?key=wk_public",
+                            headers={"Referer": "https://antonijevic.rs/kontakt"})
+        self.assertEqual(r.status_code, 200)
+
+    def test_foreign_parent_rejected_when_strict(self):
+        with patch.object(wr, "ORIGIN_STRICT", True):
+            r = self.client.get("/widget/chat?key=wk_public",
+                                headers={"Referer": "https://evil.example/steal"})
+        self.assertEqual(r.status_code, 403)
+        self.assertIn("not enabled for this site", r.text)
+
+    def test_foreign_parent_only_logged_when_not_strict(self):
+        with patch.object(wr, "ORIGIN_STRICT", False):
+            r = self.client.get("/widget/chat?key=wk_public",
+                                headers={"Referer": "https://evil.example/steal"})
+        self.assertEqual(r.status_code, 200)
+
+    def test_missing_referer_is_allowed(self):
+        # Sites with a strict referrer policy must not break their own widget.
+        with patch.object(wr, "ORIGIN_STRICT", True):
+            r = self.client.get("/widget/chat?key=wk_public")
+        self.assertEqual(r.status_code, 200)
+
+    def test_own_origin_always_allowed(self):
+        # Dashboard preview and the wizard test chat embed this page themselves.
+        with patch.object(wr, "ORIGIN_STRICT", True):
+            r = self.client.get("/widget/chat?key=wk_public",
+                                headers={"Referer": "http://mate.local/widget/admin"})
+        self.assertEqual(r.status_code, 200)
+
+    def test_invalid_key_still_401(self):
+        r = self.client.get("/widget/chat?key=nope")
+        self.assertEqual(r.status_code, 401)
+
+
+class TestNoAllowlistIsOpen(unittest.TestCase):
+    """A key without an allowlist keeps working from anywhere."""
+
+    def setUp(self):
+        self.client, self.patcher = _client(None)
+        self.addCleanup(self.patcher.stop)
+
+    def test_chat_page_open(self):
+        with patch.object(wr, "ORIGIN_STRICT", True):
+            r = self.client.get("/widget/chat?key=wk_public",
+                                headers={"Referer": "https://anywhere.example/"})
+        self.assertEqual(r.status_code, 200)
+
+    def test_public_config_open(self):
+        with patch.object(wr, "ORIGIN_STRICT", True):
+            r = self.client.get("/widget/public-config?key=wk_public",
+                                headers={"Origin": "https://anywhere.example"})
+        self.assertEqual(r.status_code, 200)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/shared/utils/artifacts/local_folder_artifact_service.py
+++ b/shared/utils/artifacts/local_folder_artifact_service.py
@@ -38,13 +38,19 @@ class LocalFolderArtifactService(BaseArtifactService):
         filename: str,
         version: int,
     ) -> Path:
-        """Translate a logical filename into an on-disk path."""
+        """Translate a logical filename into an on-disk path.
+
+        Every part comes from the request, so the result is contained to
+        base_path — a filename of "../../.env" must not escape it.
+        """
+        from shared.utils.path_safety import resolve_within_base
+
         if self._file_has_user_namespace(filename):
             clean_name = self._strip_user_prefix(filename)
             parts = [app_name, user_id, "user", clean_name, str(version)]
         else:
             parts = [app_name, user_id, session_id, filename, str(version)]
-        return self.base_path.joinpath(*parts)
+        return resolve_within_base(self.base_path, *parts)
 
     @override
     async def save_artifact(

--- a/shared/utils/audit_service.py
+++ b/shared/utils/audit_service.py
@@ -62,12 +62,19 @@ RESOURCE_AUTH = "auth"
 
 
 def _client_ip(request: Any) -> Optional[str]:
-    """Extract client IP from FastAPI Request (supports X-Forwarded-For)."""
+    """Extract client IP from a FastAPI Request.
+
+    X-Forwarded-For is only honoured when TRUSTED_PROXY_HOSTS names the proxies
+    that set it. With the default ("*", i.e. nothing verified) any client could
+    forge the header and write arbitrary text into the audit trail.
+    """
     if request is None:
         return None
-    forwarded = getattr(request, "headers", None) and request.headers.get("X-Forwarded-For")
-    if forwarded:
-        return forwarded.split(",")[0].strip()
+    trusted = os.getenv("TRUSTED_PROXY_HOSTS", "*").strip()
+    if trusted and trusted != "*":
+        forwarded = getattr(request, "headers", None) and request.headers.get("X-Forwarded-For")
+        if forwarded:
+            return forwarded.split(",")[0].strip()
     client = getattr(request, "client", None)
     if client:
         return getattr(client, "host", None)

--- a/shared/utils/auth_utils.py
+++ b/shared/utils/auth_utils.py
@@ -5,13 +5,23 @@ Provides token verification that can be used by both auth_server and dashboard_s
 
 import logging
 import hashlib
+import os
 from datetime import datetime, timedelta
 from typing import Dict, Tuple
 
 logger = logging.getLogger(__name__)
 
-# In-memory token storage (shared across all modules)
-_active_tokens = set()
+# In-memory token storage (shared across all modules): token -> expiry time
+_active_tokens: Dict[str, datetime] = {}
+
+
+def _token_ttl() -> timedelta:
+    """Lifetime of a generated bearer token (TOKEN_TTL_HOURS, default 24h)."""
+    try:
+        hours = float(os.getenv("TOKEN_TTL_HOURS", "24"))
+    except ValueError:
+        hours = 24.0
+    return timedelta(hours=hours)
 
 # Track logged-out basic auth credentials (credential_hash -> logout_time)
 # Credentials are rejected for LOGOUT_EXPIRY_MINUTES after logout
@@ -22,20 +32,25 @@ def generate_token() -> str:
     """Generate a secure random token."""
     import secrets
     token = secrets.token_urlsafe(32)
-    _active_tokens.add(token)
+    _active_tokens[token] = datetime.now() + _token_ttl()
     logger.debug("Token generated, active_tokens count: %d", len(_active_tokens))
     return token
 
 def verify_token(token: str) -> bool:
-    """Verify if a token is valid."""
-    is_valid = token in _active_tokens
-    if not is_valid:
+    """Verify if a token is valid and not expired."""
+    expiry = _active_tokens.get(token)
+    if expiry is None:
         logger.debug("Token verification failed, active_tokens count: %d", len(_active_tokens))
-    return is_valid
+        return False
+    if datetime.now() > expiry:
+        del _active_tokens[token]
+        logger.debug("Token expired")
+        return False
+    return True
 
 def revoke_token(token: str):
     """Revoke a token."""
-    _active_tokens.discard(token)
+    _active_tokens.pop(token, None)
 
 def _hash_credentials(username: str, password: str) -> str:
     """Create a hash of username:password for tracking logged-out sessions."""

--- a/shared/utils/dashboard/dashboard_server.py
+++ b/shared/utils/dashboard/dashboard_server.py
@@ -17,6 +17,7 @@ from fastapi.templating import Jinja2Templates
 from fastapi.staticfiles import StaticFiles
 
 from shared.utils import audit_service
+from shared.utils.path_safety import resolve_within_base
 
 logger = logging.getLogger(__name__)
 
@@ -805,12 +806,12 @@ class DashboardServer:
     
     def _copy_template_agent(self, agent_name: str) -> Dict[str, Any]:
         """Copy template_agent folder to agents/{agent_name}/ directory."""
+        # Outside the try so a traversal attempt surfaces as 403, not a 500.
+        agents_dir = self.project_root / "agents"
+        dest_path = resolve_within_base(agents_dir, agent_name)
         try:
-            # Define source and destination paths
             template_path = self.project_root / "shared" / "template_agent"
-            agents_dir = self.project_root / "agents"
-            dest_path = agents_dir / agent_name
-            
+
             # Check if template exists
             if not template_path.exists():
                 return {
@@ -849,10 +850,12 @@ class DashboardServer:
     
     def _delete_agent_folder(self, agent_name: str) -> Dict[str, Any]:
         """Delete agent folder from agents/{agent_name}/ directory."""
+        # Outside the try so a traversal attempt surfaces as 403, not a 500.
+        agents_dir = self.project_root / "agents"
+        folder_path = resolve_within_base(agents_dir, agent_name)
+        if folder_path == agents_dir.resolve():
+            raise HTTPException(status_code=403, detail="Invalid path")
         try:
-            agents_dir = self.project_root / "agents"
-            folder_path = agents_dir / agent_name
-            
             # Check if folder exists
             if not folder_path.exists():
                 return {

--- a/shared/utils/models.py
+++ b/shared/utils/models.py
@@ -580,6 +580,9 @@ class WidgetApiKey(Base):
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     api_key = Column(String(255), unique=True, nullable=False, index=True)
+    # Separate secret for the /widget/api admin routes: api_key is embedded in
+    # customer pages and therefore public, admin_key never leaves the dashboard.
+    admin_key = Column(String(255), unique=True, nullable=True, index=True)
     project_id = Column(Integer, ForeignKey('projects.id'), nullable=False)
     agent_name = Column(String(255), nullable=False)
     label = Column(String(255), nullable=True)
@@ -618,6 +621,7 @@ class WidgetApiKey(Base):
         return {
             'id': self.id,
             'api_key': self.api_key,
+            'admin_key': self.admin_key,
             'project_id': self.project_id,
             'agent_name': self.agent_name,
             'label': self.label,

--- a/shared/utils/path_safety.py
+++ b/shared/utils/path_safety.py
@@ -1,0 +1,19 @@
+"""Path containment helpers for endpoints that build filesystem paths from user input."""
+
+from pathlib import Path
+from typing import Union
+
+from fastapi import HTTPException
+
+
+def resolve_within_base(base: Union[str, Path], *parts: Union[str, Path]) -> Path:
+    """Resolve ``base`` joined with ``parts``, rejecting anything outside ``base``.
+
+    Guards against ``..`` traversal and absolute-path parts (``Path("/a") / "/etc"``
+    silently drops the base). Raises HTTP 403 if the result escapes the base.
+    """
+    resolved_base = Path(base).resolve()
+    target = resolved_base.joinpath(*parts).resolve()
+    if target != resolved_base and not target.is_relative_to(resolved_base):
+        raise HTTPException(status_code=403, detail="Invalid path")
+    return target

--- a/shared/utils/tools/code_executor_tools.py
+++ b/shared/utils/tools/code_executor_tools.py
@@ -1,6 +1,11 @@
 """
 Code executor tools for agents.
-Allows agents to write and execute Python scripts in a sandboxed subprocess.
+
+Runs agent-written Python and shell commands in a subprocess. NOT a sandbox:
+the subprocess runs as the server user, with the server's environment and full
+filesystem and network access — only the timeout and output size are capped.
+Enabling this tool on an agent is equivalent to granting whoever can prompt
+that agent code execution on the host, so keep it off public/widget agents.
 """
 
 import logging

--- a/shared/utils/tools/create_agent_tool.py
+++ b/shared/utils/tools/create_agent_tool.py
@@ -30,9 +30,11 @@ def _create_root_agent_folder(agent_name: str) -> Dict[str, Any]:
     from pathlib import Path
 
     try:
+        from shared.utils.path_safety import resolve_within_base
+
         project_root = Path(__file__).resolve().parents[3]
         template_path = project_root / "shared" / "template_agent"
-        dest_path = project_root / "agents" / agent_name
+        dest_path = resolve_within_base(project_root / "agents", agent_name)
 
         if not template_path.exists():
             return {"success": False, "message": f"Template agent folder not found at {template_path}"}

--- a/shared/utils/wizard/provisioning_service.py
+++ b/shared/utils/wizard/provisioning_service.py
@@ -205,6 +205,7 @@ class WizardProvisioningService:
                 logger.warning("Failed to store site memory blocks: %s", exc)
 
         api_key = f"wk_{secrets.token_urlsafe(32)}"
+        admin_key = f"wak_{secrets.token_urlsafe(32)}"
         widget_title = (analysis or {}).get("site_name", "").strip()
         if not widget_title:
             site_url = (step_data.get("site_url") or step_data.get("store_domain") or "").strip()
@@ -224,6 +225,7 @@ class WizardProvisioningService:
         try:
             wk = WidgetApiKey(
                 api_key=api_key,
+                admin_key=admin_key,
                 project_id=project_id,
                 agent_name=root_agent_name,
                 label=f"wizard trial {tier}",
@@ -252,6 +254,7 @@ class WizardProvisioningService:
 
         return {
             "widget_api_key": api_key,
+            "widget_admin_key": admin_key,
             "chat_url": f"/widget/chat?key={api_key}",
             "project_id": project_id,
             "root_agent_name": root_agent_name,

--- a/static/js/modals/file-search.js
+++ b/static/js/modals/file-search.js
@@ -149,7 +149,7 @@ function updateFileSearchModalContent(prefix, stores, files, agentName, allStore
                             <div class="flex items-center space-x-2 flex-1">
                                 <i class="fas fa-chevron-${isExpanded ? 'down' : 'right'} text-xs text-gray-500 dark:text-gray-400 transition-transform" id="${storeId}-icon"></i>
                                 <div class="flex-1">
-                                    <p class="text-sm font-medium text-gray-900 dark:text-white">${store.display_name || store.store_name}</p>
+                                    <p class="text-sm font-medium text-gray-900 dark:text-white">${escapeHtml(store.display_name || store.store_name)}</p>
                                     <p class="text-xs text-gray-500 dark:text-gray-400">${fileCount} file${fileCount !== 1 ? 's' : ''} • ${store.store_name}</p>
                                 </div>
                             </div>
@@ -163,7 +163,7 @@ function updateFileSearchModalContent(prefix, stores, files, agentName, allStore
                                     Remove
                                 </button>
                                 <button 
-                                    onclick="event.stopPropagation(); event.preventDefault(); deleteFileSearchStore('${prefix}', '${store.store_name}', '${store.display_name || store.store_name}')"
+                                    onclick="event.stopPropagation(); event.preventDefault(); deleteFileSearchStore('${prefix}', '${escapeHtml(store.store_name)}', '${escapeHtml(store.display_name || store.store_name)}')"
                                     class="px-2 py-1 text-xs text-red-600 hover:text-red-700 border border-red-300 rounded"
                                     title="Delete store completely"
                                     type="button"
@@ -260,7 +260,7 @@ function updateFileSearchModalContent(prefix, stores, files, agentName, allStore
         } else {
             uploadStoreSelect.innerHTML = '<option value="">Select a store...</option>' + 
                 stores.map(store => 
-                    `<option value="${store.store_name}">${store.display_name || store.store_name}</option>`
+                    `<option value="${escapeHtml(store.store_name)}">${escapeHtml(store.display_name || store.store_name)}</option>`
                 ).join('');
             uploadStoreSelect.disabled = false;
         }
@@ -276,7 +276,7 @@ function updateFileSearchModalContent(prefix, stores, files, agentName, allStore
         
         if (availableStores.length > 0) {
             options += availableStores.map(store => 
-                `<option value="${store.store_name}">${store.display_name || store.store_name}</option>`
+                `<option value="${escapeHtml(store.store_name)}">${escapeHtml(store.display_name || store.store_name)}</option>`
             ).join('');
         }
         

--- a/static/js/modals/widget-keys.js
+++ b/static/js/modals/widget-keys.js
@@ -143,7 +143,8 @@ function showWidgetEmbedCode(keyId) {
             if (res.success) {
                 document.getElementById('widgetEmbedCode').textContent = res.embed_code;
                 const baseUrl = window.location.origin;
-                const adminUrl = baseUrl + '/widget/admin?key=' + encodeURIComponent(res.api_key);
+                // The admin panel takes the private admin key, never the embedded public one.
+                const adminUrl = baseUrl + '/widget/admin?key=' + encodeURIComponent(res.admin_key || res.api_key);
                 const adminLink = document.getElementById('widgetAdminLink');
                 adminLink.href = adminUrl;
                 adminLink.textContent = adminUrl;

--- a/static/js/widget/admin.js
+++ b/static/js/widget/admin.js
@@ -2,12 +2,15 @@
  * MATE Widget Admin Panel — client-side logic.
  *
  * Globals injected by template:
- *   WIDGET_API_KEY, WIDGET_AGENT_NAME, WIDGET_PROJECT_ID
+ *   WIDGET_API_KEY (public, preview widget), WIDGET_ADMIN_KEY (private, API calls),
+ *   WIDGET_AGENT_NAME, WIDGET_PROJECT_ID
  */
 (function () {
   "use strict";
 
-  var API_KEY = window.WIDGET_API_KEY || "";
+  // /widget/api routes require the admin key; the public key only serves the
+  // embedded preview widget at the bottom of this page.
+  var API_KEY = window.WIDGET_ADMIN_KEY || "";
   var BASE = window.location.origin;
 
   // --- Helpers ---------------------------------------------------------

--- a/static/js/wizard/wizard.js
+++ b/static/js/wizard/wizard.js
@@ -246,6 +246,7 @@
     t4Industry: null,
     t4Goals: [],
     trialWidgetKey: null,
+    trialAdminKey: null,
     leadSubmitted: false,
   };
 
@@ -574,7 +575,8 @@
           instructions: document.getElementById("cfgInstructions").value.trim(),
         });
         state.trialWidgetKey = d.widget_api_key || null;
-        initAppearancePanel(d.widget_api_key);
+        state.trialAdminKey = d.widget_admin_key || null;
+        initAppearancePanel(d.widget_admin_key);
         var iframe = document.getElementById("testChat");
         iframe.src = d.chat_url;
         iframe.addEventListener("load", function () {
@@ -748,9 +750,11 @@
   });
 
   // --- Resume a session after a page refresh ---------------------------
-  function restoreTest(chatUrl, widgetKey) {
+  function restoreTest(chatUrl, widgetKey, adminKey) {
     state.trialWidgetKey = widgetKey || state.trialWidgetKey;
-    if (widgetKey) initAppearancePanel(widgetKey);
+    state.trialAdminKey = adminKey || state.trialAdminKey;
+    // The appearance panel writes widget config, which needs the admin key.
+    if (state.trialAdminKey) initAppearancePanel(state.trialAdminKey);
     show("test");
     state.promptCount = Math.min(parseInt(_getCount() || "0", 10), PROMPT_LIMIT);
     updateCounter();
@@ -797,7 +801,7 @@
 
         var savedStep = ssGet(SS_STEP) || "tier";
         if (savedStep === "test" && d.widget_api_key) {
-          restoreTest(d.chat_url, d.widget_api_key);
+          restoreTest(d.chat_url, d.widget_api_key, d.widget_admin_key);
         } else if (savedStep === "lead") {
           goLead();
         } else if (savedStep === "t4-industry" || savedStep === "t4-goals") {

--- a/templates/dashboard/agents.html
+++ b/templates/dashboard/agents.html
@@ -300,7 +300,7 @@
         <script src="/static/js/agent-utils.js"></script>
         <script src="/static/js/agent-config.js"></script>
         <script src="/static/js/agent-tools.js?v=23"></script>
-        <script src="/static/js/modals/file-search.js"></script>
+        <script src="/static/js/modals/file-search.js?v=21"></script>
         <script src="/static/js/agent-forms.js"></script>
         <script src="/static/js/modals/project-management.js"></script>
         <script src="/static/js/agents-page.js"></script>
@@ -309,7 +309,7 @@
         <script src="/static/js/modals/parent-agents-modal.js"></script>
         <script src="/static/js/modals/agent-edit-helpers.js"></script>
         <script src="/static/js/modals/memory-blocks.js"></script>
-        <script src="/static/js/modals/widget-keys.js"></script>
+        <script src="/static/js/modals/widget-keys.js?v=21"></script>
         <script src="/static/js/modals/version-history.js"></script>
         <script src="/static/js/modals/template-sync.js"></script>
 

--- a/templates/dashboard/agents_visual.html
+++ b/templates/dashboard/agents_visual.html
@@ -155,12 +155,12 @@ projects_list=projects
 <script src="/static/js/agent-utils.js?v=20"></script>
 <script src="/static/js/agent-config.js?v=20"></script>
 <script src="/static/js/agent-tools.js?v=23"></script>
-<script src="/static/js/modals/file-search.js?v=20"></script>
+<script src="/static/js/modals/file-search.js?v=21"></script>
 <script src="/static/js/agent-forms.js?v=20"></script>
 <script src="/static/js/modals/agent-edit-helpers.js?v=20"></script>
 <script src="/static/js/modals/parent-agents-modal.js?v=20"></script>
 <script src="/static/js/modals/memory-blocks.js?v=20"></script>
-<script src="/static/js/modals/widget-keys.js?v=20"></script>
+<script src="/static/js/modals/widget-keys.js?v=21"></script>
 <script src="/static/js/modals/template-sync.js?v=20"></script>
 <script src="/static/js/agents-visual-builder.js?v=21"></script>
 

--- a/templates/dashboard/audit_logs.html
+++ b/templates/dashboard/audit_logs.html
@@ -96,6 +96,12 @@
     let currentOffset = 0;
     let totalCount = 0;
 
+    function esc(s) {
+        return (s == null ? '' : String(s))
+            .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+    }
+
     function buildQuery() {
         const params = new URLSearchParams();
         params.set('limit', String(LIMIT));
@@ -159,17 +165,17 @@
             tbody.innerHTML = logs.map(function(row) {
                 var time = row.timestamp ? new Date(row.timestamp).toLocaleString() : '—';
                 var details = row.details ? (typeof row.details === 'object' ? JSON.stringify(row.details) : row.details) : '—';
-                var detailsEsc = (details + '').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
                 var resourceId = row.resource_id || '—';
-                var resourceIdEsc = (resourceId + '').replace(/"/g, '&quot;');
+                // Every field below is attacker-influenced (actor names, resource ids,
+                // and ip_address, which comes from the X-Forwarded-For header).
                 return '<tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50">' +
-                    '<td data-label="Time" class="px-3 py-2 text-xs text-gray-900 dark:text-white whitespace-nowrap">' + time + '</td>' +
-                    '<td data-label="Actor" class="px-3 py-2 text-xs text-gray-900 dark:text-white">' + (row.actor || '—') + '</td>' +
-                    '<td data-label="Action" class="px-3 py-2 text-xs text-gray-900 dark:text-white">' + (row.action || '—') + '</td>' +
-                    '<td data-label="Resource" class="px-3 py-2 text-xs text-gray-900 dark:text-white">' + (row.resource_type || '—') + '</td>' +
-                    '<td data-label="ID" class="px-3 py-2 text-xs text-gray-900 dark:text-white max-w-[120px] truncate" title="' + resourceIdEsc + '">' + resourceId + '</td>' +
-                    '<td data-label="IP" class="px-3 py-2 text-xs text-gray-500 dark:text-gray-400">' + (row.ip_address || '—') + '</td>' +
-                    '<td data-label="Details" class="px-3 py-2 text-xs text-gray-600 dark:text-gray-300 max-w-[200px] truncate" title="' + detailsEsc + '">' + details + '</td>' +
+                    '<td data-label="Time" class="px-3 py-2 text-xs text-gray-900 dark:text-white whitespace-nowrap">' + esc(time) + '</td>' +
+                    '<td data-label="Actor" class="px-3 py-2 text-xs text-gray-900 dark:text-white">' + esc(row.actor || '—') + '</td>' +
+                    '<td data-label="Action" class="px-3 py-2 text-xs text-gray-900 dark:text-white">' + esc(row.action || '—') + '</td>' +
+                    '<td data-label="Resource" class="px-3 py-2 text-xs text-gray-900 dark:text-white">' + esc(row.resource_type || '—') + '</td>' +
+                    '<td data-label="ID" class="px-3 py-2 text-xs text-gray-900 dark:text-white max-w-[120px] truncate" title="' + esc(resourceId) + '">' + esc(resourceId) + '</td>' +
+                    '<td data-label="IP" class="px-3 py-2 text-xs text-gray-500 dark:text-gray-400">' + esc(row.ip_address || '—') + '</td>' +
+                    '<td data-label="Details" class="px-3 py-2 text-xs text-gray-600 dark:text-gray-300 max-w-[200px] truncate" title="' + esc(details) + '">' + esc(details) + '</td>' +
                     '</tr>';
             }).join('');
 
@@ -183,7 +189,7 @@
                     '<button onclick="window.auditLogNext()" ' + (nextDisabled ? 'disabled' : '') + ' class="px-2 py-1 text-xs rounded ' + (nextDisabled ? 'opacity-50 cursor-not-allowed' : 'hover:bg-gray-200 dark:hover:bg-gray-600') + '">Next</button>';
             }
         } catch (e) {
-            tbody.innerHTML = '<tr><td colspan="7" class="px-3 py-4 text-sm text-red-600 dark:text-red-400">Failed to load: ' + (e.message || 'Unknown error') + '</td></tr>';
+            tbody.innerHTML = '<tr><td colspan="7" class="px-3 py-4 text-sm text-red-600 dark:text-red-400">Failed to load: ' + esc(e.message || 'Unknown error') + '</td></tr>';
             document.getElementById('totalCount').textContent = '0';
             document.getElementById('paginationArea').textContent = '';
         }

--- a/templates/dashboard/evals.html
+++ b/templates/dashboard/evals.html
@@ -501,7 +501,7 @@ async function openRunModal(testCaseId) {
             const data = await apiCall(`/dashboard/api/evals/agent/${encodeURIComponent(agentName)}/versions-list`);
             const versions = data.versions || [];
             sel.innerHTML = versions.length
-                ? versions.map(v => `<option value="${v.id}">v${v.version_number}${v.tag ? ' — ' + v.tag : ''} (${new Date(v.created_at).toLocaleDateString()})</option>`).join('')
+                ? versions.map(v => `<option value="${v.id}">v${v.version_number}${v.tag ? ' — ' + escHtml(v.tag) : ''} (${new Date(v.created_at).toLocaleDateString()})</option>`).join('')
                 : '<option value="">No versions found</option>';
         } catch (e) {
             sel.innerHTML = '<option value="">Error loading versions</option>';
@@ -532,7 +532,7 @@ async function submitRunEval() {
         resultArea.innerHTML = `
             ${passLabel} &nbsp;Score: <strong>${score}</strong>
             ${r.actual_output ? `<div class="mt-1 text-gray-500">Agent said: <em>${escHtml(r.actual_output.slice(0, 200))}${r.actual_output.length > 200 ? '…' : ''}</em></div>` : ''}
-            ${r.details ? `<div class="text-gray-400">${r.details}</div>` : ''}`;
+            ${r.details ? `<div class="text-gray-400">${escHtml(r.details)}</div>` : ''}`;
         resultArea.classList.remove('hidden');
         if (_selectedAgent) { loadTestCases(_selectedAgent); loadHistory(_selectedAgent); }
     } catch (e) {
@@ -561,7 +561,7 @@ async function runSuite() {
     const versions = versionsData.versions || [];
     const versionSel = document.getElementById('rsSuiteVersion');
     versionSel.innerHTML = versions.length
-        ? versions.map(v => `<option value="${v.id}">v${v.version_number}${v.tag ? ' — ' + v.tag : ''} (${new Date(v.created_at).toLocaleDateString()})</option>`).join('')
+        ? versions.map(v => `<option value="${v.id}">v${v.version_number}${v.tag ? ' — ' + escHtml(v.tag) : ''} (${new Date(v.created_at).toLocaleDateString()})</option>`).join('')
         : '<option value="">No versions found</option>';
 
     const cases = casesData.test_cases || [];

--- a/templates/dashboard/integrations.html
+++ b/templates/dashboard/integrations.html
@@ -159,6 +159,12 @@ window._integrationsPageData = {
     agents: {{ agents | tojson }},
 };
 
+function escHtml(str) {
+    return (str == null ? '' : String(str))
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
+
 const IntegrationsPage = {
     notify(msg, type) {
         if (typeof showNotification === 'function') showNotification(msg, type);
@@ -204,14 +210,14 @@ const IntegrationsPage = {
                 </tr>`;
             }).join('');
         } catch (err) {
-            tbody.innerHTML = `<tr><td colspan="6" class="px-4 py-4 text-center text-red-500">Error: ${err.message}</td></tr>`;
+            tbody.innerHTML = `<tr><td colspan="6" class="px-4 py-4 text-center text-red-500">Error: ${escHtml(err.message)}</td></tr>`;
         }
     },
 
     populateProjects() {
         const sel = document.getElementById('integrationProject');
         sel.innerHTML = '<option value="">— select project —</option>' +
-            window._integrationsPageData.projects.map(p => `<option value="${p.id}">${p.name}</option>`).join('');
+            window._integrationsPageData.projects.map(p => `<option value="${p.id}">${escHtml(p.name)}</option>`).join('');
     },
 
     onProjectChange() {
@@ -226,7 +232,7 @@ const IntegrationsPage = {
             String(a.project_id) === String(projectId) &&
             (!a.parent_agents || a.parent_agents.length === 0));
         sel.innerHTML = agents.length
-            ? agents.map(a => `<option value="${a.name}">${a.name}</option>`).join('')
+            ? agents.map(a => `<option value="${escHtml(a.name)}">${escHtml(a.name)}</option>`).join('')
             : '<option value="">— no root agents in project —</option>';
     },
 

--- a/templates/widget/admin.html
+++ b/templates/widget/admin.html
@@ -243,7 +243,8 @@
   </div>
 
   <script>
-    window.WIDGET_API_KEY = "{{ api_key }}";
+    window.WIDGET_API_KEY = "{{ api_key }}";       // public key — preview widget only
+    window.WIDGET_ADMIN_KEY = "{{ admin_key }}";   // private key — /widget/api calls
     window.WIDGET_AGENT_NAME = "{{ agent_name }}";
     window.WIDGET_PROJECT_ID = {{ project_id }};
 
@@ -268,6 +269,6 @@
       document.body.appendChild(s);
     })();
   </script>
-  <script src="/static/js/widget/admin.js"></script>
+  <script src="/static/js/widget/admin.js?v=2"></script>
 </body>
 </html>

--- a/templates/wizard/wizard.html
+++ b/templates/wizard/wizard.html
@@ -256,6 +256,6 @@
 
   </div>
 
-  <script src="/static/js/wizard/wizard.js?v=15"></script>
+  <script src="/static/js/wizard/wizard.js?v=16"></script>
 </body>
 </html>


### PR DESCRIPTION
## Context

An external reporter emailed an arbitrary file read in `GET /builder/app/{app_name}`. That is fixed here, and a full review of auth, authorization, path handling, injection sinks and XSS turned up several issues that outrank it. Everything through medium severity is fixed in this PR.

## Findings fixed

### Critical

| # | Issue |
|---|---|
| C1 | **OAuth display name granted admin.** `display_name == AUTH_USERNAME` (default `"admin"`) was accepted as proof of admin. Provider profile names are attacker-chosen and signup is open, so renaming a GitHub profile to "admin" gave full platform admin. Admin now requires a provider-verified `user_id`/`email` or the DB `admin` role, plus optional `OAUTH_ALLOWED_DOMAINS` / `OAUTH_ALLOWED_EMAILS`. |
| C2 | **57 of 66 mutating `/dashboard/api` routes had no role check.** Pages called `_get_is_admin`, the JSON APIs behind them did not — so any signed-in user (even a fresh `pending` SSO account) could `POST /dashboard/api/users` with `roles=["admin"]`. New `DashboardAuthzMiddleware` denies non-admin writes by default with an explicit allowlist. |
| C3 | **Destructive path traversal.** `agent_name` reached `shutil.rmtree`/`copytree` unchecked, so `DELETE /dashboard/api/agents/../delete-folder` resolved to the repo root. |

### High

| # | Issue |
|---|---|
| H1 | **The public widget key was also the widget admin key** — it authorised rewriting `instruction`/`model_name`, memory-block CRUD and file upload, and `GET /widget/api/agent` returned `mcp_servers_config` (which carries credentials). Adds a separate `admin_key` (migration `V025`, backfills existing rows) and a trimmed agent response. |
| H2 | **Origin allowlist bypass** — `startswith` matching let `https://victim.com.evil.com` pass an entry of `https://victim.com`. Now scheme+host+port equality with `*.domain` support. |
| H3 | **Stored XSS in the audit log page** — actor/action/resource/ip/details went into `innerHTML` unescaped, and `ip_address` came from a raw `X-Forwarded-For`, so an unauthenticated request could store script that runs in an admin's browser. |

### Medium

Bearer tokens never expired (`TOKEN_TTL_HOURS`, default 24h) · open redirect via OAuth `?next=` · `secrets.compare_digest` for credential comparisons · `X-Forwarded-For` only trusted when `TRUSTED_PROXY_HOSTS` is set · internal exception text no longer returned to widget callers · corrected the `code_executor` docstring that claimed a sandbox it does not provide.

Also included: path containment in the builder endpoints, the local artifact service and `create_agent_tool`; admin-only proxying of `builder` routes; loopback bind defaults for both agent runtimes.

### Reported but not a bug

`download_build` resolves a server-generated `build_id` against an in-memory dict — no user-controlled path, no change needed.

### Checked and clean

SQL is parameterized throughout · no `eval`/`pickle`/`yaml.load` · the binary-build subprocess passes an argv list · widget memory-block routes are project-scoped · auth-server CORS is a strict env allowlist with `allow_credentials=False` · `POST /triggers/{id}/fire` verifies a hashed fire key.

## Compatibility

**Unaffected:** embedded chat widgets (public key unchanged), basic-auth/bearer/PAT users (all already resolve to admin), agent runtime, RBAC on chat, MCP, triggers.

**Intentionally blocked:** OAuth users without the DB `admin` role lose dashboard write access — the point of C2. Work Room stays usable; its only write (`workroom/title`) is allowlisted.

**One-time steps:** anyone who was admin *only* via a matching display name needs the `admin` role (the basic-auth login always works, so no lockout). The widget admin panel and the wizard appearance editor move to the new admin key; `WIDGET_LEGACY_ADMIN_KEY=true` temporarily re-accepts the public key for unknown external callers. `WIDGET_ORIGIN_STRICT` starts in log-only mode.

**Deliberately not changed:** proxy-header trust (would break OAuth redirect URIs behind TLS), chat-route origin behavior (server-side integrations send no `Origin`), agent-name character rules (containment only, no regex).

## Verification

`506 tests passing` (was 450) — 5 new suites cover dashboard authorization, the OAuth admin decision, widget key separation, audit hardening and token expiry.

Live-verified against a running server (`AGENT_FRAMEWORK=adk`):

```
DELETE /dashboard/api/agents/../delete-folder  -> 403   (agents dir untouched)
POST   /dashboard/api/users (no auth)          -> 307   (login redirect)
GET    /widget/api/agent  (public key)         -> 401
GET    /widget/api/agent  (admin key)          -> 200, no mcp/tool/guardrail config
POST   /widget/api/chat   (public key)         -> 200, streams normally
GET    /builder/app/x?file_path=../../.env     -> 403
```

Full sell-wizard run end to end (embed → session → provision → test chat → appearance → lead → dashboard leads → convert/delete): all green. That run caught one regression introduced by this PR — `GET /widget/api/widget-config` was left on the public key while `PUT` moved to the admin key, breaking the wizard's appearance panel; both now require the admin key. Test data created during verification was cleaned up.

Migration `V025` applied on SQLite and confirmed: all existing widget keys have an `admin_key`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)