### PR TITLE
Fix V026 failing on PostgreSQL (alert_rules migration never recorded)

### DIFF
--- a/shared/sql/migrations/postgresql/V026__alert_rules.sql
+++ b/shared/sql/migrations/postgresql/V026__alert_rules.sql
@@ -27,6 +27,17 @@ CREATE INDEX IF NOT EXISTS idx_ar_is_enabled     ON alert_rules(is_enabled);
 CREATE INDEX IF NOT EXISTS idx_ar_scope          ON alert_rules(scope, scope_id);
 CREATE INDEX IF NOT EXISTS idx_ar_condition_type ON alert_rules(condition_type);
 
+-- No migration ever creates update_updated_at_column(); V012 only references it, and
+-- the whole file is executed as a single statement, so a missing function rolls the
+-- table back with it. Define it here so this migration stands on its own.
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $func$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$func$ LANGUAGE plpgsql;
+
 DO $$
 BEGIN
     IF NOT EXISTS (


### PR DESCRIPTION
Follow-up to #63. On the deployed PostgreSQL instance the migrations page still shows **025** — `V026__alert_rules` fails and rolls back, so it is never recorded and the backfill never runs.

## Cause

No migration ever creates `update_updated_at_column()`. `V012__triggers.sql` only *references* it, and V026 copied that shape. `MigrationSystem._split_sql_statements` returns the entire file as a single statement whenever it contains a `DO $$` block, so the missing function takes the `CREATE TABLE` down with it. The failure is logged and swallowed — `_apply_migration` rolls back and returns `False`, and startup continues.

Reproduced on PostgreSQL 16 against a database without the function: V026 fails before this change, applies after it. The same reproduction shows **V012 fails too** on such a database — a pre-existing latent bug, left alone here.

## Why the page still worked

`DatabaseClient._auto_create_tables` runs `Base.metadata.create_all` on startup, so `alert_rules` exists through the ORM regardless. That is why the Alerts page renders and rules can be created — the table is there, and only two things are missing:

- the `schema_migrations` row, hence the 025 reading
- **the backfill**, so any `rate_limit_config` with an `alert_webhook_url` and a daily budget did not get its migrated alert rule

The `updated_at` trigger was also absent, which is harmless in practice since SQLAlchemy sets the column through `onupdate`.

## Fix

Define `update_updated_at_column()` in V026 before installing the trigger, so the migration stands on its own.

## Verification

On PostgreSQL 16, starting from a database with no such function and a seeded `rate_limit_config`:

- migration applies (`V026 applied: True`)
- the backfill produces exactly one rule, for the row that had a webhook URL
- an `UPDATE` on `alert_rules` fires the trigger

SQLite re-verified end to end (`python -m shared.migrate run` on an empty database, 18 columns present); MySQL untouched by this change. Full suite green — 590 tests.

## After merge

The migration will apply on the next restart. Worth confirming afterwards that the migrations page reads 026, and that anyone who had a budget webhook configured under Rate Limits now sees a rule named `Budget alert: <scope> <id>` with `created_by = migration_v026`.

Separately, alerts are still dormant until `ALERTS_ENABLED=true` is set — the scheduler job is not registered without it, so no rule fires regardless of what is configured. The startup log line to look for is `TriggerRunner: registered alert evaluation every 60s`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ToCUNy2SqwvfTq4a6xfSk1)_