### PR TITLE
Response feedback, latency and tokens per conversation (#22)

### DIFF
--- a/documents/DASHBOARD_FEATURES.md
+++ b/documents/DASHBOARD_FEATURES.md
@@ -137,6 +137,13 @@ Opening a new session (New Chat button) closes and fully resets the canvas — n
   - Daily usage trends
   - Hourly usage patterns
   - Filter by time period (7/30/90 days)
+  - **Satisfaction**: share of thumbs-up among rated responses, shown with the number
+    rated out of the number that could have been rated, plus a per-agent breakdown
+  - **Response latency**: p50 and p95 over responses that finished, counting unfinished
+    invocations separately rather than as zero. Scheduled triggers, evals and other
+    background work are excluded so the figure describes what a person waited for
+  - **Tokens per conversation**: successful token usage grouped by session, mean and median
+    (MATE has no per-model pricing, so this is tokens, not money)
 - **Logs View (Raw Data)**: 
   - **Time Filters**: Last Hour, 3 Hours, 6 Hours, 12 Hours, 1 Day, 3 Days, 7 Days, 30 Days
   - **Pagination**: 50, 100, 200, or 500 records per page

--- a/server/rate_limit_middleware.py
+++ b/server/rate_limit_middleware.py
@@ -40,8 +40,11 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         if any(path.startswith(p) for p in self.skip_paths):
             return await call_next(request)
 
-        # Only rate limit run_sse and widget chat
-        if path != "/run_sse" and not path.startswith("/widget/api/chat"):
+        # Only rate limit run_sse and the public widget endpoints. Feedback is included
+        # because it is unauthenticated beyond the widget's public key, so a visitor
+        # could otherwise hammer it freely.
+        if path != "/run_sse" and not path.startswith("/widget/api/chat") \
+                and not path.startswith("/widget/api/feedback"):
             return await call_next(request)
 
         user_id = "anonymous"

--- a/server/widget_routes.py
+++ b/server/widget_routes.py
@@ -364,6 +364,37 @@ async def widget_admin_page(request: Request, key: str = Query(...)):
 # Widget Chat API
 # ---------------------------------------------------------------------------
 
+@router.post("/api/feedback")
+async def widget_feedback(request: Request, wk: WidgetApiKey = Depends(verify_widget_key)):
+    """Record a visitor's thumbs up/down on one agent response.
+
+    Rating is a visitor action, so it is scoped by the widget's public key. The agent
+    and project come from the key rather than the body — a visitor must not be able to
+    attribute a rating to someone else's agent.
+    """
+    from shared.utils.feedback_service import get_feedback_service
+
+    body = await request.json()
+    session_id = (body.get("session_id") or "").strip()
+    message_id = (body.get("message_id") or "").strip()
+    rating = (body.get("rating") or "").strip()
+    comment = body.get("comment")
+
+    if not session_id or not message_id:
+        raise HTTPException(status_code=400, detail="session_id and message_id are required")
+    if rating not in ("up", "down"):
+        raise HTTPException(status_code=400, detail="rating must be 'up' or 'down'")
+
+    result = get_feedback_service().submit(
+        session_id=session_id, message_id=message_id, rating=rating,
+        agent_name=wk.agent_name, project_id=wk.project_id,
+        comment=comment if isinstance(comment, str) else None,
+    )
+    if not result:
+        raise HTTPException(status_code=500, detail="Failed to record feedback")
+    return {"feedback": {"message_id": result["message_id"], "rating": result["rating"]}}
+
+
 @router.post("/api/chat")
 async def widget_chat(request: Request, wk: WidgetApiKey = Depends(verify_widget_key)):
     """SSE streaming chat — proxies to ADK /run_sse scoped to the widget's agent."""

--- a/shared/callbacks/metrics_plugin.py
+++ b/shared/callbacks/metrics_plugin.py
@@ -1,0 +1,65 @@
+"""
+Response timing plugin for the ADK runtime.
+
+Registered unconditionally, unlike MatePlugin — every surface that reaches the ADK
+Runner is timed, including A2A and MCP calls that never touch the auth server. It
+implements only the run-level hooks, so it cannot double-execute against the
+per-agent model callbacks wired in agent_manager.
+"""
+
+import logging
+import time
+from typing import Any, Dict, Optional
+
+from google.adk.agents.invocation_context import InvocationContext
+from google.adk.plugins.base_plugin import BasePlugin
+from google.genai import types
+
+from ..utils.response_metrics import finish_response, start_response
+
+logger = logging.getLogger(__name__)
+
+
+class MetricsPlugin(BasePlugin):
+    """Times each invocation and writes one agent_responses row."""
+
+    def __init__(self, name: str = "mate_metrics"):
+        super().__init__(name)
+        # invocation_id -> (monotonic start, wall-clock start)
+        self._started: Dict[str, tuple] = {}
+
+    async def before_run_callback(
+        self, *, invocation_context: InvocationContext
+    ) -> Optional[types.Content]:
+        try:
+            from datetime import datetime, timezone
+            invocation_id = invocation_context.invocation_id
+            self._started[invocation_id] = time.monotonic()
+            session = getattr(invocation_context, 'session', None)
+            agent = getattr(invocation_context, 'agent', None)
+            start_response(
+                invocation_id=invocation_id,
+                started_at=datetime.now(timezone.utc),
+                session_id=getattr(session, 'id', None) if session else None,
+                user_id=getattr(invocation_context, 'user_id', None),
+                agent_name=getattr(agent, 'name', None) if agent else None,
+            )
+        except Exception as e:
+            logger.debug("Response timing start skipped: %s", e)
+        return None
+
+    async def after_run_callback(
+        self, *, invocation_context: InvocationContext
+    ) -> None:
+        try:
+            invocation_id = invocation_context.invocation_id
+            monotonic_start = self._started.pop(invocation_id, None)
+            if monotonic_start is None:
+                return
+            finish_response(
+                invocation_id=invocation_id,
+                duration_ms=int((time.monotonic() - monotonic_start) * 1000),
+            )
+        except Exception as e:
+            logger.debug("Response timing skipped: %s", e)
+        return None

--- a/shared/callbacks/token_usage_callback.py
+++ b/shared/callbacks/token_usage_callback.py
@@ -138,8 +138,11 @@ def log_token_usage_callback(
     if llm_response.usage_metadata:
         usage = llm_response.usage_metadata
         
-        # Generate unique request ID for this LLM call
-        request_id = str(uuid.uuid4())
+        # The invocation id groups every model call made while answering one user
+        # turn, so "what did this response cost" is a GROUP BY. A per-call uuid, which
+        # this used to be, cannot be tied back to a response at all. The LangGraph
+        # runtime already keys its rows this way.
+        request_id = _get_invocation_id(callback_context) or str(uuid.uuid4())
         timestamp = datetime.now().isoformat()
         
         # Get session information from ADK context using the proper properties
@@ -266,6 +269,15 @@ def log_token_usage_callback(
             logger.debug("Tracing span end skipped: %s", e)
     
     return None  # Continue with normal processing
+
+
+def _get_invocation_id(callback_context: CallbackContext) -> Optional[str]:
+    """Return the ADK invocation id for the turn being answered, if reachable."""
+    try:
+        invocation = getattr(callback_context, '_invocation_context', None)
+        return getattr(invocation, 'invocation_id', None) if invocation else None
+    except Exception:
+        return None
 
 
 def _get_adk_session_info(callback_context: CallbackContext) -> tuple[str, str]:

--- a/shared/sql/migrations/mysql/V027__agent_responses.sql
+++ b/shared/sql/migrations/mysql/V027__agent_responses.sql
@@ -1,0 +1,19 @@
+-- Migration: Agent Responses (per-invocation latency)
+-- Version: V027
+-- Database: MySQL
+
+CREATE TABLE IF NOT EXISTS agent_responses (
+    id            INT AUTO_INCREMENT PRIMARY KEY,
+    invocation_id VARCHAR(255) NOT NULL,
+    session_id    VARCHAR(255),
+    user_id       VARCHAR(255),
+    agent_name    VARCHAR(255),
+    origin        VARCHAR(20)  NOT NULL DEFAULT 'chat',
+    started_at    DATETIME     NOT NULL,
+    duration_ms   INT,
+    status        VARCHAR(50)  NOT NULL DEFAULT 'SUCCESS',
+    INDEX idx_ares_invocation (invocation_id),
+    INDEX idx_ares_session    (session_id),
+    INDEX idx_ares_agent_time (agent_name, started_at),
+    INDEX idx_ares_origin     (origin)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/shared/sql/migrations/mysql/V028__response_feedback.sql
+++ b/shared/sql/migrations/mysql/V028__response_feedback.sql
@@ -1,0 +1,20 @@
+-- Migration: Response Feedback (thumbs up/down)
+-- Version: V028
+-- Database: MySQL
+
+CREATE TABLE IF NOT EXISTS response_feedback (
+    id         INT AUTO_INCREMENT PRIMARY KEY,
+    session_id VARCHAR(255) NOT NULL,
+    message_id VARCHAR(255) NOT NULL,
+    agent_name VARCHAR(255),
+    project_id INT,
+    rating     VARCHAR(10)  NOT NULL,
+    comment    TEXT,
+    created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT uq_rf_session_message UNIQUE (session_id, message_id),
+    CONSTRAINT fk_rf_project FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
+    INDEX idx_rf_agent_time (agent_name, created_at),
+    INDEX idx_rf_project    (project_id),
+    INDEX idx_rf_rating     (rating)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/shared/sql/migrations/postgresql/V027__agent_responses.sql
+++ b/shared/sql/migrations/postgresql/V027__agent_responses.sql
@@ -1,0 +1,20 @@
+-- Migration: Agent Responses (per-invocation latency)
+-- Version: V027
+-- Database: PostgreSQL
+
+CREATE TABLE IF NOT EXISTS agent_responses (
+    id            SERIAL PRIMARY KEY,
+    invocation_id VARCHAR(255) NOT NULL,
+    session_id    VARCHAR(255),
+    user_id       VARCHAR(255),
+    agent_name    VARCHAR(255),
+    origin        VARCHAR(20)  NOT NULL DEFAULT 'chat',
+    started_at    TIMESTAMP WITH TIME ZONE NOT NULL,
+    duration_ms   INTEGER,
+    status        VARCHAR(50)  NOT NULL DEFAULT 'SUCCESS'
+);
+
+CREATE INDEX IF NOT EXISTS idx_ares_invocation ON agent_responses(invocation_id);
+CREATE INDEX IF NOT EXISTS idx_ares_session    ON agent_responses(session_id);
+CREATE INDEX IF NOT EXISTS idx_ares_agent_time ON agent_responses(agent_name, started_at);
+CREATE INDEX IF NOT EXISTS idx_ares_origin     ON agent_responses(origin);

--- a/shared/sql/migrations/postgresql/V028__response_feedback.sql
+++ b/shared/sql/migrations/postgresql/V028__response_feedback.sql
@@ -1,0 +1,42 @@
+-- Migration: Response Feedback (thumbs up/down)
+-- Version: V028
+-- Database: PostgreSQL
+
+CREATE TABLE IF NOT EXISTS response_feedback (
+    id         SERIAL PRIMARY KEY,
+    session_id VARCHAR(255) NOT NULL,
+    message_id VARCHAR(255) NOT NULL,
+    agent_name VARCHAR(255),
+    project_id INTEGER REFERENCES projects(id) ON DELETE CASCADE,
+    rating     VARCHAR(10)  NOT NULL CHECK (rating IN ('up', 'down')),
+    comment    TEXT,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_rf_session_message UNIQUE (session_id, message_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_rf_agent_time ON response_feedback(agent_name, created_at);
+CREATE INDEX IF NOT EXISTS idx_rf_project    ON response_feedback(project_id);
+CREATE INDEX IF NOT EXISTS idx_rf_rating     ON response_feedback(rating);
+
+-- update_updated_at_column() is created in V012; defined here too so this migration
+-- does not depend on that one having run.
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $func$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$func$ LANGUAGE plpgsql;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_trigger
+        WHERE tgname = 'update_response_feedback_updated_at'
+    ) THEN
+        CREATE TRIGGER update_response_feedback_updated_at
+            BEFORE UPDATE ON response_feedback
+            FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+    END IF;
+END $$;

--- a/shared/sql/migrations/sqlite/V027__agent_responses.sql
+++ b/shared/sql/migrations/sqlite/V027__agent_responses.sql
@@ -1,0 +1,20 @@
+-- Migration: Agent Responses (per-invocation latency)
+-- Version: V027
+-- Database: SQLite
+
+CREATE TABLE IF NOT EXISTS agent_responses (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    invocation_id VARCHAR(255) NOT NULL,
+    session_id    VARCHAR(255),
+    user_id       VARCHAR(255),
+    agent_name    VARCHAR(255),
+    origin        VARCHAR(20)  NOT NULL DEFAULT 'chat',
+    started_at    DATETIME     NOT NULL,
+    duration_ms   INTEGER,
+    status        VARCHAR(50)  NOT NULL DEFAULT 'SUCCESS'
+);
+
+CREATE INDEX IF NOT EXISTS idx_ares_invocation ON agent_responses(invocation_id);
+CREATE INDEX IF NOT EXISTS idx_ares_session    ON agent_responses(session_id);
+CREATE INDEX IF NOT EXISTS idx_ares_agent_time ON agent_responses(agent_name, started_at);
+CREATE INDEX IF NOT EXISTS idx_ares_origin     ON agent_responses(origin);

--- a/shared/sql/migrations/sqlite/V028__response_feedback.sql
+++ b/shared/sql/migrations/sqlite/V028__response_feedback.sql
@@ -1,0 +1,20 @@
+-- Migration: Response Feedback (thumbs up/down)
+-- Version: V028
+-- Database: SQLite
+
+CREATE TABLE IF NOT EXISTS response_feedback (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id VARCHAR(255) NOT NULL,
+    message_id VARCHAR(255) NOT NULL,
+    agent_name VARCHAR(255),
+    project_id INTEGER REFERENCES projects(id) ON DELETE CASCADE,
+    rating     VARCHAR(10)  NOT NULL CHECK (rating IN ('up', 'down')),
+    comment    TEXT,
+    created_at DATETIME     NOT NULL DEFAULT (datetime('now')),
+    updated_at DATETIME     NOT NULL DEFAULT (datetime('now')),
+    CONSTRAINT uq_rf_session_message UNIQUE (session_id, message_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_rf_agent_time ON response_feedback(agent_name, created_at);
+CREATE INDEX IF NOT EXISTS idx_rf_project    ON response_feedback(project_id);
+CREATE INDEX IF NOT EXISTS idx_rf_rating     ON response_feedback(rating);

--- a/shared/test/test_response_feedback.py
+++ b/shared/test/test_response_feedback.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""
+Unit tests for response feedback.
+
+The satisfaction rate must count responses, not clicks: a visitor who changes their
+mind has to overwrite their rating rather than add a second one. The public endpoint
+is reachable with nothing but a widget key, so the agent and project it records must
+come from the key, never from the request body.
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from shared.utils.feedback_service import FeedbackService, MAX_COMMENT
+from shared.utils.models import Base, ResponseFeedback
+
+
+class TestFeedbackService(unittest.TestCase):
+
+    def setUp(self):
+        self.engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(self.engine)
+        self.Session = sessionmaker(bind=self.engine)
+        self.db_client = MagicMock()
+        self.db_client.is_connected.return_value = True
+        self.db_client.get_session.side_effect = lambda: self.Session()
+        with patch("shared.utils.feedback_service.get_database_client",
+                   return_value=self.db_client):
+            self.service = FeedbackService()
+
+    def tearDown(self):
+        self.engine.dispose()
+
+    def _count(self):
+        session = self.Session()
+        try:
+            return session.query(ResponseFeedback).count()
+        finally:
+            session.close()
+
+    def test_records_a_rating(self):
+        result = self.service.submit(session_id="s1", message_id="e-1", rating="up",
+                                     agent_name="a1", project_id=7)
+        self.assertEqual(result["rating"], "up")
+        self.assertEqual(result["agent_name"], "a1")
+        self.assertEqual(result["project_id"], 7)
+        self.assertEqual(self._count(), 1)
+
+    def test_changing_a_rating_overwrites_it(self):
+        # Otherwise one indecisive visitor moves the satisfaction rate on their own
+        self.service.submit(session_id="s1", message_id="e-1", rating="up")
+        self.service.submit(session_id="s1", message_id="e-1", rating="down")
+        self.assertEqual(self._count(), 1)
+        session = self.Session()
+        self.assertEqual(session.query(ResponseFeedback).one().rating, "down")
+        session.close()
+
+    def test_different_messages_are_separate_ratings(self):
+        self.service.submit(session_id="s1", message_id="e-1", rating="up")
+        self.service.submit(session_id="s1", message_id="e-2", rating="up")
+        self.assertEqual(self._count(), 2)
+
+    def test_same_message_id_in_another_session_is_separate(self):
+        self.service.submit(session_id="s1", message_id="e-1", rating="up")
+        self.service.submit(session_id="s2", message_id="e-1", rating="up")
+        self.assertEqual(self._count(), 2)
+
+    def test_rejects_an_unknown_rating(self):
+        self.assertIsNone(self.service.submit(session_id="s1", message_id="e-1",
+                                              rating="sideways"))
+        self.assertEqual(self._count(), 0)
+
+    def test_rejects_missing_identifiers(self):
+        self.assertIsNone(self.service.submit(session_id="", message_id="e-1", rating="up"))
+        self.assertIsNone(self.service.submit(session_id="s1", message_id="", rating="up"))
+
+    def test_comment_is_truncated(self):
+        result = self.service.submit(session_id="s1", message_id="e-1", rating="down",
+                                     comment="x" * (MAX_COMMENT + 500))
+        self.assertEqual(len(result["comment"]), MAX_COMMENT)
+
+    def test_changing_a_rating_keeps_an_earlier_comment(self):
+        self.service.submit(session_id="s1", message_id="e-1", rating="down",
+                            comment="was wrong about the price")
+        result = self.service.submit(session_id="s1", message_id="e-1", rating="up")
+        self.assertEqual(result["comment"], "was wrong about the price")
+
+    def test_ratings_for_a_session_are_readable(self):
+        self.service.submit(session_id="s1", message_id="e-1", rating="up")
+        self.service.submit(session_id="s1", message_id="e-2", rating="down")
+        self.service.submit(session_id="s2", message_id="e-3", rating="up")
+        self.assertEqual(self.service.get_for_session("s1"), {"e-1": "up", "e-2": "down"})
+
+    def test_no_database_degrades_quietly(self):
+        self.db_client.is_connected.return_value = False
+        self.assertIsNone(self.service.submit(session_id="s1", message_id="e-1", rating="up"))
+        self.assertEqual(self.service.get_for_session("s1"), {})
+
+
+class TestWidgetFeedbackEndpoint(unittest.TestCase):
+    """The public surface: a widget key is the only credential a visitor has."""
+
+    def setUp(self):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        import server.widget_routes as wr
+
+        self.wr = wr
+        self.widget_key = MagicMock(id=1, agent_name="support_root", project_id=42)
+
+        app = FastAPI()
+        app.include_router(wr.router)
+        app.dependency_overrides[wr.verify_widget_key] = lambda: self.widget_key
+        self.client = TestClient(app)
+
+        self.service = MagicMock()
+        self.service.submit.return_value = {"message_id": "e-1", "rating": "up"}
+        self.patcher = patch("shared.utils.feedback_service.get_feedback_service",
+                             return_value=self.service)
+        self.patcher.start()
+
+    def tearDown(self):
+        self.patcher.stop()
+
+    def test_records_a_rating(self):
+        resp = self.client.post("/widget/api/feedback", json={
+            "session_id": "s1", "message_id": "e-1", "rating": "up"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["feedback"]["rating"], "up")
+
+    def test_agent_and_project_come_from_the_key(self):
+        # A visitor must not be able to attribute a rating to someone else's agent
+        self.client.post("/widget/api/feedback", json={
+            "session_id": "s1", "message_id": "e-1", "rating": "up",
+            "agent_name": "someone_elses_agent", "project_id": 999})
+        kwargs = self.service.submit.call_args.kwargs
+        self.assertEqual(kwargs["agent_name"], "support_root")
+        self.assertEqual(kwargs["project_id"], 42)
+
+    def test_rejects_a_bad_rating(self):
+        resp = self.client.post("/widget/api/feedback", json={
+            "session_id": "s1", "message_id": "e-1", "rating": "maybe"})
+        self.assertEqual(resp.status_code, 400)
+
+    def test_rejects_missing_identifiers(self):
+        resp = self.client.post("/widget/api/feedback", json={"rating": "up"})
+        self.assertEqual(resp.status_code, 400)
+
+    def test_storage_failure_is_reported(self):
+        self.service.submit.return_value = None
+        resp = self.client.post("/widget/api/feedback", json={
+            "session_id": "s1", "message_id": "e-1", "rating": "up"})
+        self.assertEqual(resp.status_code, 500)
+
+
+class TestFeedbackIsRateLimited(unittest.TestCase):
+
+    def test_middleware_covers_the_public_feedback_path(self):
+        # It is reachable with only a public key, so it must not be unthrottled
+        import inspect
+        from server import rate_limit_middleware
+        source = inspect.getsource(rate_limit_middleware)
+        self.assertIn("/widget/api/feedback", source)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/shared/test/test_response_metrics.py
+++ b/shared/test/test_response_metrics.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""
+Unit tests for per-response metrics.
+
+Latency is recorded at the runtime's invocation boundary because only two of the
+eight surfaces that invoke an agent pass through the auth server's proxy. If the
+plugin stops being registered, or origin classification drifts, the usage page
+quietly reports percentiles over the wrong population.
+"""
+
+import asyncio
+import os
+import sys
+import unittest
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from shared.utils.models import AgentResponse, Base
+from shared.utils.response_metrics import finish_response, resolve_origin, start_response
+
+
+class TestResolveOrigin(unittest.TestCase):
+
+    def test_background_callers_are_not_chat(self):
+        # A trigger that runs for two minutes must not define the p95 a customer reads
+        self.assertEqual(resolve_origin("trigger_runner", None), "trigger")
+        self.assertEqual(resolve_origin("eval_runner", None), "eval")
+
+    def test_session_prefixes(self):
+        self.assertEqual(resolve_origin("u1", "openai_sess_abc"), "api")
+        self.assertEqual(resolve_origin("u1", "slack_T123_C456"), "slack")
+
+    def test_defaults_to_chat(self):
+        self.assertEqual(resolve_origin("u1", "some-session"), "chat")
+        self.assertEqual(resolve_origin(None, None), "chat")
+
+    def test_user_id_wins_over_session_prefix(self):
+        # A trigger firing an agent that happens to use a slack session is still a trigger
+        self.assertEqual(resolve_origin("trigger_runner", "slack_T_C"), "trigger")
+
+
+class TestRecordResponse(unittest.TestCase):
+
+    def setUp(self):
+        self.engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(self.engine)
+        self.Session = sessionmaker(bind=self.engine)
+        self.db_client = MagicMock()
+        self.db_client.is_connected.return_value = True
+        self.db_client.get_session.side_effect = lambda: self.Session()
+        self.patcher = patch("shared.utils.response_metrics.get_database_client",
+                             return_value=self.db_client)
+        self.patcher.start()
+
+    def tearDown(self):
+        self.patcher.stop()
+        self.engine.dispose()
+
+    def _row(self, invocation_id):
+        session = self.Session()
+        try:
+            return session.query(AgentResponse).filter(
+                AgentResponse.invocation_id == invocation_id).one()
+        finally:
+            session.close()
+
+    def test_open_then_close(self):
+        self.assertTrue(start_response(invocation_id="inv-1", session_id="openai_sess_x",
+                                       user_id="u1", agent_name="a1"))
+        opened = self._row("inv-1")
+        self.assertEqual(opened.status, "RUNNING")
+        self.assertIsNone(opened.duration_ms)
+        self.assertEqual(opened.origin, "api")
+
+        self.assertTrue(finish_response(invocation_id="inv-1", duration_ms=1234))
+        closed = self._row("inv-1")
+        self.assertEqual(closed.status, "SUCCESS")
+        self.assertEqual(closed.duration_ms, 1234)
+
+    def test_unfinished_invocation_stays_visible(self):
+        # ADK skips its after-run hook when an invocation raises, so a failed response
+        # leaves the row RUNNING instead of disappearing entirely
+        start_response(invocation_id="inv-hung", agent_name="a1")
+        row = self._row("inv-hung")
+        self.assertEqual(row.status, "RUNNING")
+        self.assertIsNone(row.duration_ms)
+
+    def test_closing_twice_is_a_no_op(self):
+        start_response(invocation_id="inv-2", agent_name="a1")
+        self.assertTrue(finish_response(invocation_id="inv-2", duration_ms=10))
+        self.assertFalse(finish_response(invocation_id="inv-2", duration_ms=99))
+        self.assertEqual(self._row("inv-2").duration_ms, 10)
+
+    def test_closing_an_unknown_invocation_is_a_no_op(self):
+        self.assertFalse(finish_response(invocation_id="never-opened", duration_ms=5))
+
+    def test_error_status_is_recorded(self):
+        start_response(invocation_id="inv-3", agent_name="a1")
+        finish_response(invocation_id="inv-3", duration_ms=42, status="ERROR")
+        row = self._row("inv-3")
+        self.assertEqual(row.status, "ERROR")
+        self.assertEqual(row.duration_ms, 42)
+
+    def test_database_failure_is_swallowed(self):
+        # This runs beside a live response — it must never surface to the caller
+        self.db_client.get_session.side_effect = RuntimeError("db down")
+        self.assertFalse(start_response(invocation_id="inv-4"))
+        self.assertFalse(finish_response(invocation_id="inv-4", duration_ms=1))
+
+    def test_no_database_returns_false(self):
+        self.db_client.is_connected.return_value = False
+        self.assertFalse(start_response(invocation_id="inv-5"))
+        self.assertFalse(finish_response(invocation_id="inv-5", duration_ms=1))
+
+
+class TestMetricsPlugin(unittest.TestCase):
+
+    def _context(self, invocation_id="inv-9"):
+        return SimpleNamespace(
+            invocation_id=invocation_id,
+            user_id="u1",
+            session=SimpleNamespace(id="s1"),
+            agent=SimpleNamespace(name="a1"),
+        )
+
+    def test_times_the_whole_invocation(self):
+        from shared.callbacks.metrics_plugin import MetricsPlugin
+        plugin = MetricsPlugin()
+        ctx = self._context()
+        with patch("shared.callbacks.metrics_plugin.start_response") as opened, \
+                patch("shared.callbacks.metrics_plugin.finish_response") as closed:
+            asyncio.run(plugin.before_run_callback(invocation_context=ctx))
+            asyncio.run(plugin.after_run_callback(invocation_context=ctx))
+        open_kwargs = opened.call_args.kwargs
+        self.assertEqual(open_kwargs["invocation_id"], "inv-9")
+        self.assertEqual(open_kwargs["agent_name"], "a1")
+        self.assertEqual(open_kwargs["session_id"], "s1")
+        close_kwargs = closed.call_args.kwargs
+        self.assertEqual(close_kwargs["invocation_id"], "inv-9")
+        self.assertGreaterEqual(close_kwargs["duration_ms"], 0)
+
+    def test_after_without_before_records_nothing(self):
+        from shared.callbacks.metrics_plugin import MetricsPlugin
+        plugin = MetricsPlugin()
+        with patch("shared.callbacks.metrics_plugin.finish_response") as record:
+            asyncio.run(plugin.after_run_callback(invocation_context=self._context()))
+        record.assert_not_called()
+
+    def test_start_state_does_not_leak(self):
+        from shared.callbacks.metrics_plugin import MetricsPlugin
+        plugin = MetricsPlugin()
+        ctx = self._context()
+        with patch("shared.callbacks.metrics_plugin.start_response"), \
+                patch("shared.callbacks.metrics_plugin.finish_response"):
+            asyncio.run(plugin.before_run_callback(invocation_context=ctx))
+            asyncio.run(plugin.after_run_callback(invocation_context=ctx))
+        self.assertEqual(plugin._started, {})
+
+    def test_recording_failure_does_not_raise(self):
+        from shared.callbacks.metrics_plugin import MetricsPlugin
+        plugin = MetricsPlugin()
+        ctx = self._context()
+        with patch("shared.callbacks.metrics_plugin.start_response",
+                   side_effect=RuntimeError("boom")), \
+                patch("shared.callbacks.metrics_plugin.finish_response",
+                      side_effect=RuntimeError("boom")):
+            asyncio.run(plugin.before_run_callback(invocation_context=ctx))
+            asyncio.run(plugin.after_run_callback(invocation_context=ctx))
+
+    def test_implements_no_model_callbacks(self):
+        # It is registered alongside the per-agent model callbacks, so overriding any
+        # of those here would double-execute them
+        from shared.callbacks.metrics_plugin import MetricsPlugin
+        from google.adk.plugins.base_plugin import BasePlugin
+        for hook in ("before_model_callback", "after_model_callback",
+                     "on_model_error_callback", "before_tool_callback"):
+            self.assertIs(getattr(MetricsPlugin, hook), getattr(BasePlugin, hook), hook)
+
+
+class TestPluginRegistration(unittest.TestCase):
+
+    def test_metrics_plugin_registered_without_mate_plugins_enabled(self):
+        # The whole point is that latency does not depend on that flag
+        import inspect
+        from shared.utils import utils
+        source = inspect.getsource(utils)
+        metrics_at = source.index("MetricsPlugin()")
+        gate_at = source.index('MATE_PLUGINS_ENABLED", "false"')
+        self.assertLess(metrics_at, gate_at,
+                        "MetricsPlugin must be appended before the MATE_PLUGINS_ENABLED gate")
+
+
+class TestInvocationIdGrouping(unittest.TestCase):
+
+    def test_token_rows_use_the_invocation_id(self):
+        # Without this, one response's several model calls cannot be grouped at all
+        from shared.callbacks.token_usage_callback import _get_invocation_id
+        ctx = SimpleNamespace()
+        ctx._invocation_context = SimpleNamespace(invocation_id="e-42")
+        self.assertEqual(_get_invocation_id(ctx), "e-42")
+
+    def test_missing_invocation_context_is_tolerated(self):
+        from shared.callbacks.token_usage_callback import _get_invocation_id
+        self.assertIsNone(_get_invocation_id(SimpleNamespace()))
+        self.assertIsNone(_get_invocation_id(object()))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/shared/test/test_usage_quality_stats.py
+++ b/shared/test/test_usage_quality_stats.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""
+Unit tests for the satisfaction, latency and conversation panels.
+
+These are the numbers a customer is shown, so the population they are computed
+over matters more than the arithmetic: percentiles must ignore invocations that
+never finished, background work must not be mixed into a figure that claims to
+describe what a person waited for, and a satisfaction rate has to carry the size
+of the sample it came from.
+"""
+
+import os
+import sys
+import unittest
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from shared.utils.models import AgentResponse, Base, ResponseFeedback, TokenUsageLog
+from shared.utils.dashboard.dashboard_server import DashboardServer
+
+
+class TestPercentile(unittest.TestCase):
+
+    def setUp(self):
+        from fastapi import FastAPI
+        self.server = DashboardServer(FastAPI(), Path(os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
+
+    def test_empty_is_zero(self):
+        self.assertEqual(self.server._percentile([], 0.5), 0)
+
+    def test_single_value(self):
+        self.assertEqual(self.server._percentile([7], 0.5), 7)
+        self.assertEqual(self.server._percentile([7], 0.95), 7)
+
+    def test_nearest_rank(self):
+        values = list(range(1, 101))
+        self.assertEqual(self.server._percentile(values, 0.50), 50)
+        self.assertEqual(self.server._percentile(values, 0.95), 95)
+
+    def test_never_indexes_past_the_end(self):
+        self.assertEqual(self.server._percentile([1, 2, 3], 1.0), 3)
+
+
+class TestQualityStats(unittest.TestCase):
+
+    def setUp(self):
+        self.engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(self.engine)
+        self.Session = sessionmaker(bind=self.engine)
+
+        self.mock_db_client = MagicMock()
+        self.mock_db_client.get_session.side_effect = lambda: self.Session()
+        self.patcher = patch('shared.utils.database_client.get_database_client',
+                             return_value=self.mock_db_client)
+        self.patcher.start()
+
+        from fastapi import FastAPI
+        self.server = DashboardServer(FastAPI(), Path(os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
+        self.server.db_client = self.mock_db_client
+
+        self.now = datetime.now()
+        self.start = self.now - timedelta(days=7)
+
+    def tearDown(self):
+        self.patcher.stop()
+        self.engine.dispose()
+
+    def _stats(self):
+        session = self.Session()
+        try:
+            return self.server._get_quality_stats(session, self.start, self.now)
+        finally:
+            session.close()
+
+    def _response(self, duration_ms, origin="chat", minutes_ago=10, agent="a1"):
+        session = self.Session()
+        session.add(AgentResponse(
+            invocation_id=f"i-{origin}-{duration_ms}-{minutes_ago}-{agent}",
+            session_id="s1", user_id="u1", agent_name=agent, origin=origin,
+            started_at=self.now - timedelta(minutes=minutes_ago),
+            duration_ms=duration_ms,
+            status='SUCCESS' if duration_ms is not None else 'RUNNING'))
+        session.commit()
+        session.close()
+
+    def _rating(self, rating, agent="a1", message="m1"):
+        session = self.Session()
+        session.add(ResponseFeedback(session_id="s1", message_id=message,
+                                     agent_name=agent, rating=rating,
+                                     created_at=self.now - timedelta(minutes=5)))
+        session.commit()
+        session.close()
+
+    def _tokens(self, session_id, prompt, response, minutes_ago=10, status='SUCCESS'):
+        session = self.Session()
+        session.add(TokenUsageLog(
+            request_id=f"r-{session_id}-{prompt}-{minutes_ago}", session_id=session_id,
+            user_id="u1", agent_name="a1", model_name="m",
+            prompt_tokens=prompt, response_tokens=response, status=status,
+            timestamp=self.now - timedelta(minutes=minutes_ago)))
+        session.commit()
+        session.close()
+
+    # --- satisfaction ---------------------------------------------------
+
+    def test_satisfaction_rate_and_sample_size(self):
+        for i in range(3):
+            self._rating("up", message=f"m{i}")
+        self._rating("down", message="m9")
+        for i in range(10):
+            self._response(1000, minutes_ago=i + 1)
+
+        s = self._stats()["satisfaction"]
+        self.assertEqual(s["up"], 3)
+        self.assertEqual(s["down"], 1)
+        self.assertEqual(s["rated"], 4)
+        self.assertEqual(s["rate_pct"], 75.0)
+        # The denominator a reader needs: 4 ratings out of 10 answerable responses
+        self.assertEqual(s["responses"], 10)
+
+    def test_no_ratings_reports_none_not_zero(self):
+        # 0% would read as "everyone hated it" rather than "nobody said"
+        self._response(1000)
+        s = self._stats()["satisfaction"]
+        self.assertIsNone(s["rate_pct"])
+        self.assertEqual(s["rated"], 0)
+
+    def test_per_agent_breakdown(self):
+        self._rating("up", agent="a1", message="m1")
+        self._rating("up", agent="a1", message="m2")
+        self._rating("down", agent="a2", message="m3")
+        rows = {r["agent"]: r for r in self._stats()["satisfaction"]["per_agent"]}
+        self.assertEqual(rows["a1"]["rate_pct"], 100.0)
+        self.assertEqual(rows["a2"]["rate_pct"], 0.0)
+        self.assertEqual(rows["a2"]["rated"], 1)
+
+    # --- latency --------------------------------------------------------
+
+    def test_percentiles_over_finished_responses(self):
+        for ms in [100, 200, 300, 400, 500]:
+            self._response(ms, minutes_ago=ms // 100)
+        latency = self._stats()["latency"]
+        self.assertEqual(latency["samples"], 5)
+        self.assertEqual(latency["p50_ms"], 300)
+        self.assertEqual(latency["p95_ms"], 500)
+
+    def test_unfinished_responses_are_counted_not_averaged(self):
+        # Treating a hung invocation as zero would flatter p95
+        self._response(1000, minutes_ago=1)
+        self._response(None, minutes_ago=2)
+        self._response(None, minutes_ago=3)
+        latency = self._stats()["latency"]
+        self.assertEqual(latency["samples"], 1)
+        self.assertEqual(latency["p50_ms"], 1000)
+        self.assertEqual(latency["unfinished"], 2)
+
+    def test_background_work_is_excluded(self):
+        # A nightly trigger must not define the latency a customer reads
+        self._response(500, origin="chat", minutes_ago=1)
+        self._response(120000, origin="trigger", minutes_ago=2)
+        self._response(90000, origin="eval", minutes_ago=3)
+        latency = self._stats()["latency"]
+        self.assertEqual(latency["samples"], 1)
+        self.assertEqual(latency["p95_ms"], 500)
+
+    def test_api_traffic_counts_as_interactive(self):
+        self._response(400, origin="api", minutes_ago=1)
+        self.assertEqual(self._stats()["latency"]["samples"], 1)
+
+    def test_outside_the_window_is_excluded(self):
+        self._response(500, minutes_ago=1)
+        self._response(9999, minutes_ago=60 * 24 * 30)
+        self.assertEqual(self._stats()["latency"]["samples"], 1)
+
+    # --- conversations --------------------------------------------------
+
+    def test_tokens_grouped_by_conversation(self):
+        # Two turns of one conversation are one conversation, not two
+        self._tokens("conv-1", 100, 200, minutes_ago=5)
+        self._tokens("conv-1", 50, 150, minutes_ago=4)
+        self._tokens("conv-2", 10, 20, minutes_ago=3)
+        conversations = self._stats()["conversations"]
+        self.assertEqual(conversations["count"], 2)
+        # (500 + 30) / 2
+        self.assertEqual(conversations["avg_tokens"], 265)
+
+    def test_failed_calls_do_not_count_toward_conversation_cost(self):
+        self._tokens("conv-1", 100, 200, minutes_ago=5)
+        self._tokens("conv-1", 0, 0, minutes_ago=4, status='ERROR')
+        conversations = self._stats()["conversations"]
+        self.assertEqual(conversations["count"], 1)
+        self.assertEqual(conversations["avg_tokens"], 300)
+
+    def test_no_data_is_zero_not_an_error(self):
+        stats = self._stats()
+        self.assertEqual(stats["conversations"]["count"], 0)
+        self.assertEqual(stats["latency"]["samples"], 0)
+        self.assertIsNone(stats["satisfaction"]["rate_pct"])
+
+    def test_quality_panels_reach_the_usage_stats(self):
+        self._response(700, minutes_ago=1)
+        self._rating("up")
+        stats = self.server._get_usage_stats(days=7)
+        self.assertIn("satisfaction", stats)
+        self.assertIn("latency", stats)
+        self.assertIn("conversations", stats)
+        self.assertEqual(stats["latency"]["p50_ms"], 700)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/shared/utils/dashboard/dashboard_server.py
+++ b/shared/utils/dashboard/dashboard_server.py
@@ -3341,6 +3341,60 @@ class DashboardServer:
                 return {"success": False, "error": str(e)}
 
         # ---------- Personal Access Tokens API ----------
+        @self.app.post("/dashboard/api/feedback", tags=["Dashboard - Feedback"])
+        async def submit_feedback(
+            request: Request,
+            username: str = Depends(self._get_auth_user_dependency),
+        ):
+            """Record a thumbs up/down from the workroom chat."""
+            from shared.utils.feedback_service import get_feedback_service
+
+            body = await request.json()
+            session_id = (body.get("session_id") or "").strip()
+            message_id = (body.get("message_id") or "").strip()
+            rating = (body.get("rating") or "").strip()
+            if not session_id or not message_id:
+                raise HTTPException(status_code=400,
+                                    detail="session_id and message_id are required")
+            if rating not in ("up", "down"):
+                raise HTTPException(status_code=400, detail="rating must be 'up' or 'down'")
+
+            agent_name = (body.get("agent_name") or "").strip() or None
+            project_id = None
+            if agent_name and self.db_client:
+                # Resolved from the agent rather than trusted from the body
+                db = self.db_client.get_session()
+                if db:
+                    try:
+                        row = db.query(self.AgentConfig.project_id).filter(
+                            self.AgentConfig.name == agent_name).first()
+                        project_id = row[0] if row else None
+                    except Exception:
+                        project_id = None
+                    finally:
+                        db.close()
+
+            comment = body.get("comment")
+            result = get_feedback_service().submit(
+                session_id=session_id, message_id=message_id, rating=rating,
+                agent_name=agent_name, project_id=project_id,
+                comment=comment if isinstance(comment, str) else None,
+            )
+            if not result:
+                raise HTTPException(status_code=500, detail="Failed to record feedback")
+            return {"feedback": {"message_id": result["message_id"],
+                                 "rating": result["rating"]}}
+
+        @self.app.get("/dashboard/api/feedback", tags=["Dashboard - Feedback"])
+        async def list_session_feedback(
+            request: Request,
+            session_id: str,
+            username: str = Depends(self._get_auth_user_dependency),
+        ):
+            """Ratings already given in a session, so a reloaded chat shows them."""
+            from shared.utils.feedback_service import get_feedback_service
+            return {"ratings": get_feedback_service().get_for_session(session_id)}
+
         @self.app.get("/dashboard/api/tokens", tags=["Dashboard - Users"])
         async def list_user_tokens(
             request: Request,

--- a/shared/utils/dashboard/dashboard_server.py
+++ b/shared/utils/dashboard/dashboard_server.py
@@ -5,6 +5,7 @@ Basic dashboard endpoints without complex service dependencies
 
 import json
 import logging
+import math
 import os
 import sys
 import shutil
@@ -287,7 +288,7 @@ class DashboardServer:
                 hour = int(hour_stat.hour)
                 hourly_data[hour] = hour_stat.requests
             
-            return {
+            result = {
                 'total_requests': stats.total_requests or 0,
                 'total_prompt_tokens': stats.total_prompt_tokens or 0,
                 'total_response_tokens': stats.total_response_tokens or 0,
@@ -298,12 +299,160 @@ class DashboardServer:
                 'hourly_usage': hourly_data,
                 'database_info': self._get_database_info()
             }
+            result.update(self._get_quality_stats(session, start_date, end_date))
+            return result
         except Exception as e:
             print(f"Error getting usage stats: {e}")
             return {"error": str(e)}
         finally:
             session.close()
     
+    @staticmethod
+    def _percentile(sorted_values: List[int], fraction: float) -> int:
+        """Nearest-rank percentile.
+
+        Computed in Python rather than SQL because SQLite has no PERCENTILE_CONT and
+        the samples here are small enough that pulling the durations costs nothing.
+        """
+        if not sorted_values:
+            return 0
+        index = max(0, math.ceil(fraction * len(sorted_values)) - 1)
+        return int(sorted_values[min(index, len(sorted_values) - 1)])
+
+    # Latency a customer would recognise: what someone waited on, not what a
+    # scheduled job took. The rest stays in the table and is reachable by filter.
+    INTERACTIVE_ORIGINS = ('chat', 'api')
+
+    def _get_quality_stats(self, session, start_date, end_date) -> Dict[str, Any]:
+        """Satisfaction, response latency and tokens per conversation.
+
+        Kept apart from the token panels above: these read agent_responses and
+        response_feedback, and a failure in any of them must not blank the whole
+        usage page.
+        """
+        from sqlalchemy import func
+
+        empty = {
+            'satisfaction': {'up': 0, 'down': 0, 'rated': 0, 'rate_pct': None,
+                             'responses': 0, 'per_agent': []},
+            'latency': {'p50_ms': 0, 'p95_ms': 0, 'samples': 0, 'unfinished': 0},
+            'conversations': {'count': 0, 'avg_tokens': 0, 'median_tokens': 0},
+        }
+        try:
+            from shared.utils.models import AgentResponse, ResponseFeedback
+        except Exception as e:
+            logger.warning("Quality stats unavailable: %s", e)
+            return empty
+
+        stats = {}
+
+        # --- Satisfaction -------------------------------------------------
+        try:
+            rows = session.query(
+                ResponseFeedback.agent_name,
+                ResponseFeedback.rating,
+                func.count(ResponseFeedback.id).label('n'),
+            ).filter(
+                ResponseFeedback.created_at >= start_date,
+                ResponseFeedback.created_at <= end_date,
+            ).group_by(ResponseFeedback.agent_name, ResponseFeedback.rating).all()
+
+            per_agent = {}
+            total_up = total_down = 0
+            for agent_name, rating, n in rows:
+                bucket = per_agent.setdefault(agent_name or 'unknown', {'up': 0, 'down': 0})
+                bucket[rating] = bucket.get(rating, 0) + int(n or 0)
+                if rating == 'up':
+                    total_up += int(n or 0)
+                else:
+                    total_down += int(n or 0)
+
+            # The denominator that matters is how many responses could have been
+            # rated — a 100% score over three ratings is not a satisfaction rate.
+            responses = session.query(func.count(AgentResponse.id)).filter(
+                AgentResponse.started_at >= start_date,
+                AgentResponse.started_at <= end_date,
+                AgentResponse.origin.in_(self.INTERACTIVE_ORIGINS),
+            ).scalar() or 0
+
+            rated = total_up + total_down
+            stats['satisfaction'] = {
+                'up': total_up,
+                'down': total_down,
+                'rated': rated,
+                'rate_pct': round(100.0 * total_up / rated, 1) if rated else None,
+                'responses': int(responses),
+                'per_agent': sorted(
+                    [{'agent': a,
+                      'up': v['up'],
+                      'down': v['down'],
+                      'rated': v['up'] + v['down'],
+                      'rate_pct': round(100.0 * v['up'] / (v['up'] + v['down']), 1)
+                      if (v['up'] + v['down']) else None}
+                     for a, v in per_agent.items()],
+                    key=lambda r: r['rated'], reverse=True)[:10],
+            }
+        except Exception as e:
+            logger.warning("Satisfaction stats failed: %s", e)
+            stats['satisfaction'] = empty['satisfaction']
+
+        # --- Latency ------------------------------------------------------
+        try:
+            durations = [
+                int(r[0]) for r in session.query(AgentResponse.duration_ms).filter(
+                    AgentResponse.started_at >= start_date,
+                    AgentResponse.started_at <= end_date,
+                    AgentResponse.duration_ms.isnot(None),
+                    AgentResponse.origin.in_(self.INTERACTIVE_ORIGINS),
+                ).all() if r[0] is not None
+            ]
+            durations.sort()
+            # Invocations that never closed: ADK skips its after-run hook on failure,
+            # so these are errors or hangs. Counting them as zero would flatter p95.
+            unfinished = session.query(func.count(AgentResponse.id)).filter(
+                AgentResponse.started_at >= start_date,
+                AgentResponse.started_at <= end_date,
+                AgentResponse.duration_ms.is_(None),
+                AgentResponse.origin.in_(self.INTERACTIVE_ORIGINS),
+            ).scalar() or 0
+
+            stats['latency'] = {
+                'p50_ms': self._percentile(durations, 0.50),
+                'p95_ms': self._percentile(durations, 0.95),
+                'samples': len(durations),
+                'unfinished': int(unfinished),
+            }
+        except Exception as e:
+            logger.warning("Latency stats failed: %s", e)
+            stats['latency'] = empty['latency']
+
+        # --- Tokens per conversation ---------------------------------------
+        try:
+            per_session = [
+                int(r[0] or 0) for r in session.query(
+                    func.sum(
+                        func.coalesce(self.TokenUsageLog.prompt_tokens, 0) +
+                        func.coalesce(self.TokenUsageLog.response_tokens, 0)
+                    )
+                ).filter(
+                    self.TokenUsageLog.status == 'SUCCESS',
+                    self.TokenUsageLog.timestamp >= start_date,
+                    self.TokenUsageLog.timestamp <= end_date,
+                    self.TokenUsageLog.session_id.isnot(None),
+                ).group_by(self.TokenUsageLog.session_id).all()
+            ]
+            per_session.sort()
+            stats['conversations'] = {
+                'count': len(per_session),
+                'avg_tokens': int(sum(per_session) / len(per_session)) if per_session else 0,
+                'median_tokens': self._percentile(per_session, 0.50),
+            }
+        except Exception as e:
+            logger.warning("Conversation stats failed: %s", e)
+            stats['conversations'] = empty['conversations']
+
+        return stats
+
     def _get_database_info(self) -> dict:
         """Get database connection information."""
         db_type = os.getenv("DB_TYPE", "sqlite").upper()

--- a/shared/utils/feedback_service.py
+++ b/shared/utils/feedback_service.py
@@ -1,0 +1,106 @@
+"""
+Response feedback: a visitor's thumbs up/down on one agent response.
+
+Ratings are keyed by (session_id, message_id) where message_id is the invocation id,
+which is what lets a rating be joined to that response's cost and latency. Rating the
+same message again changes the existing row rather than adding another, so the
+satisfaction rate counts responses, not clicks.
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from .database_client import get_database_client
+from .models import ResponseFeedback
+
+logger = logging.getLogger(__name__)
+
+RATINGS = ('up', 'down')
+MAX_COMMENT = 2000
+
+
+class FeedbackService:
+    """Upsert and read response ratings."""
+
+    def __init__(self):
+        self.db_client = get_database_client()
+
+    def _get_session(self):
+        if not self.db_client or not self.db_client.is_connected():
+            return None
+        return self.db_client.get_session()
+
+    def submit(self, session_id: str, message_id: str, rating: str,
+               agent_name: Optional[str] = None, project_id: Optional[int] = None,
+               comment: Optional[str] = None) -> Optional[Dict[str, Any]]:
+        """Record or change a rating. Returns the stored row, or None on failure."""
+        if rating not in RATINGS:
+            return None
+        if not session_id or not message_id:
+            return None
+
+        session = self._get_session()
+        if not session:
+            return None
+        try:
+            existing = session.query(ResponseFeedback).filter(
+                ResponseFeedback.session_id == session_id,
+                ResponseFeedback.message_id == message_id,
+            ).first()
+
+            if existing:
+                existing.rating = rating
+                # A visitor changing their mind should not silently drop the comment
+                # they wrote, but an explicit new comment replaces it.
+                if comment is not None:
+                    existing.comment = comment[:MAX_COMMENT] or None
+                existing.updated_at = datetime.now(timezone.utc)
+                row = existing
+            else:
+                row = ResponseFeedback(
+                    session_id=session_id,
+                    message_id=message_id,
+                    agent_name=agent_name,
+                    project_id=project_id,
+                    rating=rating,
+                    comment=(comment or '')[:MAX_COMMENT] or None,
+                )
+                session.add(row)
+
+            session.commit()
+            session.refresh(row)
+            return row.to_dict()
+        except Exception as e:
+            session.rollback()
+            logger.error("Failed to submit feedback for %s/%s: %s",
+                         session_id, message_id, e)
+            return None
+        finally:
+            session.close()
+
+    def get_for_session(self, session_id: str) -> Dict[str, str]:
+        """message_id -> rating for one session, so a reloaded chat shows its ratings."""
+        session = self._get_session()
+        if not session:
+            return {}
+        try:
+            rows = session.query(
+                ResponseFeedback.message_id, ResponseFeedback.rating
+            ).filter(ResponseFeedback.session_id == session_id).all()
+            return {r[0]: r[1] for r in rows}
+        except Exception as e:
+            logger.error("Failed to read feedback for session %s: %s", session_id, e)
+            return {}
+        finally:
+            session.close()
+
+
+_feedback_service: Optional[FeedbackService] = None
+
+
+def get_feedback_service() -> FeedbackService:
+    global _feedback_service
+    if _feedback_service is None:
+        _feedback_service = FeedbackService()
+    return _feedback_service

--- a/shared/utils/langgraph/runner.py
+++ b/shared/utils/langgraph/runner.py
@@ -5,7 +5,9 @@ graph invocation and the ADK-shape event translation behind POST /run_sse.
 
 import json
 import logging
+import time
 import uuid
+from datetime import datetime, timezone
 from typing import Any, AsyncGenerator, Dict
 
 logger = logging.getLogger(__name__)
@@ -31,6 +33,16 @@ async def run_sse_stream(app_name: str, user_id: str, session_id: str,
                          new_message: Dict[str, Any]) -> AsyncGenerator[str, None]:
     """Stream ADK Event JSON frames for one /run_sse invocation."""
     invocation_id = f"e-{uuid.uuid4()}"
+    # This is the LangGraph equivalent of the ADK run boundary: every surface on this
+    # runtime arrives through /run_sse, and it has no A2A or MCP of its own.
+    started_monotonic = time.monotonic()
+    status = "SUCCESS"
+    try:
+        from shared.utils.response_metrics import start_response
+        start_response(invocation_id=invocation_id, started_at=datetime.now(timezone.utc),
+                       session_id=session_id, user_id=user_id, agent_name=app_name)
+    except Exception:
+        logger.debug("[LangGraph] opening response metrics failed", exc_info=True)
     try:
         from shared.utils.langgraph.executor import execute_run
         async for event in execute_run(app_name=app_name, user_id=user_id,
@@ -38,6 +50,7 @@ async def run_sse_stream(app_name: str, user_id: str, session_id: str,
                                        invocation_id=invocation_id):
             yield _sse_frame(event)
     except Exception as e:
+        status = "ERROR"
         logger.exception(f"[LangGraph] run_sse failed for app={app_name} session={session_id}")
         # Own try/except: a logging failure must not stop the error frame reaching the client
         try:
@@ -51,3 +64,13 @@ async def run_sse_stream(app_name: str, user_id: str, session_id: str,
             "error_message": str(e),
             **_error_event(app_name, "An error occurred while processing your request.", invocation_id),
         })
+    finally:
+        try:
+            from shared.utils.response_metrics import finish_response
+            finish_response(
+                invocation_id=invocation_id,
+                duration_ms=int((time.monotonic() - started_monotonic) * 1000),
+                status=status,
+            )
+        except Exception:
+            logger.debug("[LangGraph] closing response metrics failed", exc_info=True)

--- a/shared/utils/models.py
+++ b/shared/utils/models.py
@@ -1143,6 +1143,42 @@ class AgentTrigger(Base):
         }
 
 
+class AgentResponse(Base):
+    """One row per agent invocation: how long the whole response took, and where from.
+
+    token_usage_logs records per-LLM-call cost but no duration, and the HTTP layer
+    cannot supply one — six of the eight surfaces that invoke an agent bypass the
+    proxy entirely. This is written at the runtime's invocation boundary instead, so
+    every transport is covered by the same code.
+    """
+
+    __tablename__ = 'agent_responses'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    invocation_id = Column(String(255), nullable=False)
+    session_id = Column(String(255), nullable=True)
+    user_id = Column(String(255), nullable=True)
+    agent_name = Column(String(255), nullable=True)
+    # chat | api | trigger | slack | eval | mcp | a2a — see resolve_origin()
+    origin = Column(String(20), nullable=False, default='chat')
+    started_at = Column(DateTime, nullable=False)
+    duration_ms = Column(Integer, nullable=True)
+    status = Column(String(50), nullable=False, default='SUCCESS')
+
+    def to_dict(self) -> dict:
+        return {
+            'id': self.id,
+            'invocation_id': self.invocation_id,
+            'session_id': self.session_id,
+            'user_id': self.user_id,
+            'agent_name': self.agent_name,
+            'origin': self.origin,
+            'started_at': self.started_at.isoformat() if self.started_at else None,
+            'duration_ms': self.duration_ms,
+            'status': self.status,
+        }
+
+
 class AlertRule(Base):
     """Notification rule: a condition over recorded events, a destination, a cooldown.
 

--- a/shared/utils/models.py
+++ b/shared/utils/models.py
@@ -2,7 +2,7 @@
 SQLAlchemy models for the application.
 """
 
-from sqlalchemy import Column, Integer, String, DateTime, create_engine, UUID, Text, ForeignKey, Boolean, Date, JSON, Float
+from sqlalchemy import Column, Integer, String, DateTime, create_engine, UUID, Text, ForeignKey, Boolean, Date, JSON, Float, UniqueConstraint
 from sqlalchemy.orm import sessionmaker, relationship, declarative_base
 from datetime import datetime, timezone
 from typing import Optional
@@ -1138,6 +1138,42 @@ class AgentTrigger(Base):
             'last_fired_at': self.last_fired_at.isoformat() if self.last_fired_at else None,
             'last_result': self.get_last_result(),
             'created_by': self.created_by,
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+            'updated_at': self.updated_at.isoformat() if self.updated_at else None,
+        }
+
+
+class ResponseFeedback(Base):
+    """A visitor's thumbs up/down on one agent response.
+
+    Keyed by the invocation id, which is what ties a rating to the response's cost
+    and latency. One rating per message, changed in place rather than appended.
+    """
+
+    __tablename__ = 'response_feedback'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    session_id = Column(String(255), nullable=False)
+    message_id = Column(String(255), nullable=False)
+    agent_name = Column(String(255), nullable=True)
+    project_id = Column(Integer, ForeignKey('projects.id', ondelete='CASCADE'), nullable=True)
+    rating = Column(String(10), nullable=False)  # up | down
+    comment = Column(Text, nullable=True)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False)
+    updated_at = Column(DateTime, default=lambda: datetime.now(timezone.utc),
+                        onupdate=lambda: datetime.now(timezone.utc), nullable=False)
+
+    __table_args__ = (UniqueConstraint('session_id', 'message_id', name='uq_rf_session_message'),)
+
+    def to_dict(self) -> dict:
+        return {
+            'id': self.id,
+            'session_id': self.session_id,
+            'message_id': self.message_id,
+            'agent_name': self.agent_name,
+            'project_id': self.project_id,
+            'rating': self.rating,
+            'comment': self.comment,
             'created_at': self.created_at.isoformat() if self.created_at else None,
             'updated_at': self.updated_at.isoformat() if self.updated_at else None,
         }

--- a/shared/utils/response_metrics.py
+++ b/shared/utils/response_metrics.py
@@ -1,0 +1,117 @@
+"""
+Per-response metrics: how long one agent invocation took, and where it came from.
+
+Recorded at the runtime's invocation boundary rather than in the HTTP layer. Only
+two of the eight surfaces that invoke an agent go through the auth server's proxy —
+the widget, the OpenAI-compatible endpoint, MCP, triggers, Slack and evals all open
+their own client straight to the agent process — so the HTTP layer cannot see most
+responses. The runtime sees all of them.
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Optional
+
+from .database_client import get_database_client
+from .models import AgentResponse
+
+logger = logging.getLogger(__name__)
+
+ORIGINS = ('chat', 'api', 'trigger', 'slack', 'eval')
+
+# Each internal caller already stamps something distinctive on the run; these are the
+# markers, in one place so they can be tested and kept honest.
+#   trigger  shared/utils/trigger_runner.py:339   user_id="trigger_runner"
+#   eval     shared/utils/dashboard/dashboard_server.py:128  user_id="eval_runner"
+#   api      server/openai_routes.py:128          session_id="openai_sess_…"
+#   slack    server/slack_routes.py:272           session_id="slack_…"
+# A2A and MCP carry no marker today and therefore fall under 'chat'. Splitting them
+# out needs a prefix at the point those sessions are created.
+_USER_ID_ORIGINS = {
+    'trigger_runner': 'trigger',
+    'eval_runner': 'eval',
+}
+_SESSION_PREFIX_ORIGINS = (
+    ('openai_sess_', 'api'),
+    ('slack_', 'slack'),
+)
+
+
+def resolve_origin(user_id: Optional[str], session_id: Optional[str]) -> str:
+    """Classify an invocation so background work can be kept out of user-facing stats."""
+    if user_id and user_id in _USER_ID_ORIGINS:
+        return _USER_ID_ORIGINS[user_id]
+    if session_id:
+        for prefix, origin in _SESSION_PREFIX_ORIGINS:
+            if session_id.startswith(prefix):
+                return origin
+    return 'chat'
+
+
+def _session():
+    """A DB session, or None. Never raises — this runs beside a live response."""
+    try:
+        db_client = get_database_client()
+        if not db_client or not db_client.is_connected():
+            return None
+        return db_client.get_session()
+    except Exception as e:
+        logger.warning("Response metrics unavailable: %s", e)
+        return None
+
+
+def start_response(invocation_id: str, started_at: Optional[datetime] = None,
+                   session_id: Optional[str] = None, user_id: Optional[str] = None,
+                   agent_name: Optional[str] = None) -> bool:
+    """Open a RUNNING row for an invocation.
+
+    Written up front rather than on completion because ADK does not guarantee the
+    after-run hook on a failed invocation — `_run_with_plugins` calls it after the
+    event loop rather than in a finally (google/adk/runners.py:1413). A row left
+    RUNNING is therefore a response that errored or never finished, which is worth
+    seeing rather than losing.
+    """
+    session = _session()
+    if not session:
+        return False
+    try:
+        session.add(AgentResponse(
+            invocation_id=invocation_id,
+            session_id=session_id,
+            user_id=user_id,
+            agent_name=agent_name,
+            origin=resolve_origin(user_id, session_id),
+            started_at=started_at or datetime.now(timezone.utc),
+            duration_ms=None,
+            status='RUNNING',
+        ))
+        session.commit()
+        return True
+    except Exception as e:
+        session.rollback()
+        logger.warning("Failed to open agent response %s: %s", invocation_id, e)
+        return False
+    finally:
+        session.close()
+
+
+def finish_response(invocation_id: str, duration_ms: int,
+                    status: str = 'SUCCESS') -> bool:
+    """Close the RUNNING row for an invocation with its duration."""
+    session = _session()
+    if not session:
+        return False
+    try:
+        updated = session.query(AgentResponse).filter(
+            AgentResponse.invocation_id == invocation_id,
+            AgentResponse.status == 'RUNNING',
+        ).update({'duration_ms': duration_ms, 'status': status},
+                 synchronize_session=False)
+        session.commit()
+        return updated > 0
+    except Exception as e:
+        session.rollback()
+        logger.warning("Failed to close agent response %s: %s", invocation_id, e)
+        return False
+    finally:
+        session.close()

--- a/shared/utils/utils.py
+++ b/shared/utils/utils.py
@@ -473,13 +473,28 @@ def create_app_with_context_caching(
     # Register app-wide MATE plugin (RBAC/guardrails/token tracking for all agents,
     # including agents created at runtime). agent_manager skips per-agent model
     # callbacks when this is enabled.
+    plugins = []
+
+    # Response timing is registered whatever MATE_PLUGINS_ENABLED says: it is the only
+    # place that sees every surface (A2A and MCP never reach the auth server), and it
+    # implements only run-level hooks, so it cannot collide with the per-agent
+    # model callbacks.
+    try:
+        from shared.callbacks.metrics_plugin import MetricsPlugin
+        plugins.append(MetricsPlugin())
+    except Exception as e:
+        logger.error(f"Failed to register metrics plugin: {e}. Response latency will not be recorded.")
+
     if os.getenv("MATE_PLUGINS_ENABLED", "false").lower() == "true":
         try:
             from shared.callbacks.mate_plugin import MatePlugin
-            app_kwargs['plugins'] = [MatePlugin()]
+            plugins.append(MatePlugin())
             logger.info(f"App '{effective_app_name}' MATE plugin registered (app-wide callbacks)")
         except Exception as e:
             logger.error(f"Failed to register MATE plugin: {e}. Falling back to per-agent callbacks.")
+
+    if plugins:
+        app_kwargs['plugins'] = plugins
 
     # Create and return App instance
     app = App(**app_kwargs)

--- a/static/css/widget/chat.css
+++ b/static/css/widget/chat.css
@@ -551,4 +551,18 @@ html, body {
   flex-shrink: 0;
 }
 
+/* A rating stays visible after the click, so the visitor can see it registered
+   and which way they voted. */
+.widget-message-action-btn.rated {
+  opacity: 1;
+}
+
+.widget-message-action-btn.rate-up.rated {
+  color: #16a34a;
+}
+
+.widget-message-action-btn.rate-down.rated {
+  color: #dc2626;
+}
+
 

--- a/static/js/standalone/chat.js
+++ b/static/js/standalone/chat.js
@@ -25,6 +25,8 @@
   var pendingFiles = []; // [{dataUrl, mimeType, base64, name}]
   var abortController = null;
   var activeAgentEl = null;
+  var activeInvocationId = "";
+  var ratings = {}; // invocation id -> "up" | "down", so a re-rendered row stays lit
   var activeAgentText = "";
   var activeAgentAuthor = "";
   var activeAgentImages = [];
@@ -37,12 +39,12 @@
 
   // UI string translations
   var UI_STRINGS = {
-    en: { placeholder: "Type a message…", send: "Send", newChat: "New Chat", stop: "Stop", interrupted: "Response interrupted", copy: "Copy", copied: "Copied!", download: "Download", confirmTitle: "Approval required", confirmApprove: "Approve", confirmReject: "Reject", confirmApproved: "Approved", confirmRejected: "Rejected" },
-    sr: { placeholder: "Unesite poruku…", send: "Pošalji", newChat: "Nov razgovor", stop: "Prekini", interrupted: "Odgovor je prekinut", copy: "Kopiraj", copied: "Kopirano!", download: "Preuzmi", confirmTitle: "Potrebna je potvrda", confirmApprove: "Potvrdi", confirmReject: "Odbaci", confirmApproved: "Potvrđeno", confirmRejected: "Odbačeno" },
-    hr: { placeholder: "Unesite poruku…", send: "Pošalji", newChat: "Novi razgovor", stop: "Prekini", interrupted: "Odgovor je prekinut", copy: "Kopiraj", copied: "Kopirano!", download: "Preuzmi", confirmTitle: "Potrebna je potvrda", confirmApprove: "Potvrdi", confirmReject: "Odbaci", confirmApproved: "Potvrđeno", confirmRejected: "Odbačeno" },
-    bs: { placeholder: "Unesite poruku…", send: "Pošalji", newChat: "Novi razgovor", stop: "Prekini", interrupted: "Odgovor je prekinut", copy: "Kopiraj", copied: "Kopirano!", download: "Preuzmi", confirmTitle: "Potrebna je potvrda", confirmApprove: "Potvrdi", confirmReject: "Odbaci", confirmApproved: "Potvrđeno", confirmRejected: "Odbačeno" },
-    de: { placeholder: "Nachricht eingeben…", send: "Senden", newChat: "Neuer Chat", stop: "Stoppen", interrupted: "Antwort unterbrochen", copy: "Kopieren", copied: "Kopiert!", download: "Herunterladen" },
-    fr: { placeholder: "Écrivez un message…", send: "Envoyer", newChat: "Nouveau chat", stop: "Arrêter", interrupted: "Réponse interrompue", copy: "Copier", copied: "Copié !", download: "Télécharger" },
+    en: { placeholder: "Type a message…", send: "Send", newChat: "New Chat", stop: "Stop", interrupted: "Response interrupted", copy: "Copy", copied: "Copied!", download: "Download", rateUp: "Helpful", rateDown: "Not helpful", confirmTitle: "Approval required", confirmApprove: "Approve", confirmReject: "Reject", confirmApproved: "Approved", confirmRejected: "Rejected" },
+    sr: { placeholder: "Unesite poruku…", send: "Pošalji", newChat: "Nov razgovor", stop: "Prekini", interrupted: "Odgovor je prekinut", copy: "Kopiraj", copied: "Kopirano!", download: "Preuzmi", rateUp: "Koristan odgovor", rateDown: "Nije koristan", confirmTitle: "Potrebna je potvrda", confirmApprove: "Potvrdi", confirmReject: "Odbaci", confirmApproved: "Potvrđeno", confirmRejected: "Odbačeno" },
+    hr: { placeholder: "Unesite poruku…", send: "Pošalji", newChat: "Novi razgovor", stop: "Prekini", interrupted: "Odgovor je prekinut", copy: "Kopiraj", copied: "Kopirano!", download: "Preuzmi", rateUp: "Koristan odgovor", rateDown: "Nije koristan", confirmTitle: "Potrebna je potvrda", confirmApprove: "Potvrdi", confirmReject: "Odbaci", confirmApproved: "Potvrđeno", confirmRejected: "Odbačeno" },
+    bs: { placeholder: "Unesite poruku…", send: "Pošalji", newChat: "Novi razgovor", stop: "Prekini", interrupted: "Odgovor je prekinut", copy: "Kopiraj", copied: "Kopirano!", download: "Preuzmi", rateUp: "Koristan odgovor", rateDown: "Nije koristan", confirmTitle: "Potrebna je potvrda", confirmApprove: "Potvrdi", confirmReject: "Odbaci", confirmApproved: "Potvrđeno", confirmRejected: "Odbačeno" },
+    de: { placeholder: "Nachricht eingeben…", send: "Senden", newChat: "Neuer Chat", stop: "Stoppen", interrupted: "Antwort unterbrochen", copy: "Kopieren", copied: "Kopiert!", download: "Herunterladen", rateUp: "Hilfreich", rateDown: "Nicht hilfreich" },
+    fr: { placeholder: "Écrivez un message…", send: "Envoyer", newChat: "Nouveau chat", stop: "Arrêter", interrupted: "Réponse interrompue", copy: "Copier", copied: "Copié !", download: "Télécharger", rateUp: "Utile", rateDown: "Pas utile" },
     es: { placeholder: "Escribe un mensaje…", send: "Enviar", newChat: "Nueva conversación", stop: "Detener", interrupted: "Respuesta interrumpida" },
     it: { placeholder: "Scrivi un messaggio…", send: "Invia", newChat: "Nuova chat", stop: "Interrompi", interrupted: "Risposta interrotta" },
     pt: { placeholder: "Escreva uma mensagem…", send: "Enviar", newChat: "Nova conversa", stop: "Parar", interrupted: "Resposta interrompida" },
@@ -434,6 +436,7 @@
         activeAgentEl = document.createElement("div");
         activeAgentEl.className = "widget-message agent";
         activeAgentEl.setAttribute("data-author", activeAgentAuthor);
+        if (activeInvocationId) activeAgentEl.setAttribute("data-invocation", activeInvocationId);
         activeAgentEl.innerHTML = THINKING_HTML;
         
         wrapper.appendChild(avatarEl);
@@ -450,6 +453,10 @@
 
       try {
         var evt = JSON.parse(raw);
+
+        // The invocation id identifies the response being rated, and is what ties a
+        // rating to that response's cost and latency on the server.
+        if (evt.invocationId) activeInvocationId = evt.invocationId;
 
         // Skip transfer/routing actions
         var actions = evt.actions || {};
@@ -1161,6 +1168,8 @@
   // --- SVG Icons & Actions ----------------------------------------------
   var COPY_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>';
   var CHECK_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle"><polyline points="20 6 9 17 4 12"></polyline></svg>';
+  var THUMB_UP_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle"><path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3zM7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3"></path></svg>';
+  var THUMB_DOWN_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle"><path d="M10 15v4a3 3 0 0 0 3 3l4-9V2H5.72a2 2 0 0 0-2 1.7l-1.38 9a2 2 0 0 0 2 2.3zm7-13h2.67A2.31 2.31 0 0 1 22 4v7a2.31 2.31 0 0 1-2.33 2H17"></path></svg>';
   var DOWNLOAD_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>';
 
   function _addMessageActions(messageEl) {
@@ -1222,7 +1231,58 @@
     
     actionsContainer.appendChild(copyBtn);
     actionsContainer.appendChild(downloadBtn);
+    _addRatingButtons(actionsContainer, messageEl, s);
     messageEl.appendChild(actionsContainer);
+  }
+
+  function _addRatingButtons(container, messageEl, s) {
+    // Only a response the server can identify is rateable; restored history without an
+    // invocation id simply gets no thumbs rather than a button that fails on click.
+    var invocationId = messageEl.getAttribute("data-invocation");
+    if (!invocationId) return;
+
+    function makeBtn(rating, svg, label) {
+      var btn = document.createElement("button");
+      btn.className = "widget-message-action-btn rate-btn rate-" + rating;
+      btn.title = label;
+      btn.innerHTML = svg;
+      btn.addEventListener("click", function (e) {
+        e.stopPropagation();
+        _submitRating(invocationId, rating, container);
+      });
+      return btn;
+    }
+
+    container.appendChild(makeBtn("up", THUMB_UP_SVG, (s && s.rateUp) || "Helpful"));
+    container.appendChild(makeBtn("down", THUMB_DOWN_SVG, (s && s.rateDown) || "Not helpful"));
+    _paintRating(container, ratings[invocationId]);
+  }
+
+  function _paintRating(container, rating) {
+    ["up", "down"].forEach(function (r) {
+      var btn = container.querySelector(".rate-" + r);
+      if (btn) btn.classList.toggle("rated", rating === r);
+    });
+  }
+
+  function _submitRating(invocationId, rating, container) {
+    // Optimistic: a rating is a courtesy, not a transaction — reflect the click at once
+    ratings[invocationId] = rating;
+    _paintRating(container, rating);
+
+    fetch("/dashboard/api/feedback", {
+      method: "POST",
+      credentials: "same-origin",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        session_id: sessionId,
+        message_id: invocationId,
+        rating: rating,
+        agent_name: AGENT_NAME,
+      }),
+    }).catch(function () {
+      /* the next rating retries; no need to interrupt the conversation */
+    });
   }
 
   function _fallbackCopy(text, btn, successLabel, normalLabel) {

--- a/static/js/widget/chat.js
+++ b/static/js/widget/chat.js
@@ -28,6 +28,8 @@
   let abortController = null;
   let debugMode = false;
   let activeAgentEl = null;
+  let activeInvocationId = "";
+  let ratings = {}; // invocation id -> "up" | "down", so a re-rendered row stays lit
   // Locked by wizard via postMessage when trial prompt limit is reached. Persisted in
   // localStorage so the lock survives widget iframe reloads (iframe destruction clears sessionStorage).
   const _LOCK_KEY = `${STORAGE_PREFIX}_locked`;
@@ -40,12 +42,12 @@
 
   // UI string translations — placeholder, send button, new-chat button, stop button, interrupted message
   const UI_STRINGS = {
-    en: { placeholder: "Type a message…", send: "Send", newChat: "New Chat", stop: "Stop", interrupted: "Response interrupted", copy: "Copy", copied: "Copied!", download: "Download", access_denied: "You don't have permission to use this agent. Please contact the administrator.", error_occurred: "Hmm, I couldn't quite process that. Could you say it again?", endChat: "End chat", endConfirm: "End this conversation? Your chat will be cleared.", endYes: "Yes, end", endNo: "No", confirmTitle: "Approval required", confirmApprove: "Approve", confirmReject: "Reject", confirmApproved: "Approved", confirmRejected: "Rejected" },
-    sr: { placeholder: "Unesite poruku…", send: "Pošalji", newChat: "Nov razgovor", stop: "Prekini", interrupted: "Odgovor je prekinut", copy: "Kopiraj", copied: "Kopirano!", download: "Preuzmi", access_denied: "Nemate pristup ovom agentu. Molimo kontaktirajte administratora.", error_occurred: "Hm, nisam uspeo to da obradim. Možete li da ponovite?", endChat: "Završi", endConfirm: "Završiti razgovor? Vaš chat će biti obrisan.", endYes: "Da, završi", endNo: "Ne", confirmTitle: "Potrebna je potvrda", confirmApprove: "Potvrdi", confirmReject: "Odbaci", confirmApproved: "Potvrđeno", confirmRejected: "Odbačeno" },
-    hr: { placeholder: "Unesite poruku…", send: "Pošalji", newChat: "Novi razgovor", stop: "Prekini", interrupted: "Odgovor je prekinut", copy: "Kopiraj", copied: "Kopirano!", download: "Preuzmi", access_denied: "Nemate pristup ovom agentu. Kontaktirajte administratora.", error_occurred: "Hm, nisam uspio to obraditi. Možete li ponoviti?" },
-    bs: { placeholder: "Unesite poruku…", send: "Pošalji", newChat: "Novi razgovor", stop: "Prekini", interrupted: "Odgovor je prekinut", copy: "Kopiraj", copied: "Kopirano!", download: "Preuzmi", access_denied: "Nemate pristup ovom agentu. Kontaktirajte administratora.", error_occurred: "Hm, nisam uspio to obraditi. Možete li ponoviti?" },
-    de: { placeholder: "Nachricht eingeben…", send: "Senden", newChat: "Neuer Chat", stop: "Stoppen", interrupted: "Antwort unterbrochen", copy: "Kopieren", copied: "Kopiert!", download: "Herunterladen", access_denied: "Sie haben keinen Zugriff auf diesen Agenten. Bitte kontaktieren Sie den Administrator.", error_occurred: "Hmm, das konnte ich nicht verarbeiten. Können Sie es wiederholen?" },
-    fr: { placeholder: "Écrivez un message…", send: "Envoyer", newChat: "Nouveau chat", stop: "Arrêter", interrupted: "Réponse interrompue", copy: "Copier", copied: "Copié !", download: "Télécharger", access_denied: "Vous n'avez pas accès à cet agent. Veuillez contacter l'administrateur.", error_occurred: "Hmm, je n'ai pas réussi à traiter cela. Pouvez-vous répéter ?" },
+    en: { placeholder: "Type a message…", send: "Send", newChat: "New Chat", stop: "Stop", interrupted: "Response interrupted", copy: "Copy", copied: "Copied!", download: "Download", rateUp: "Helpful", rateDown: "Not helpful", access_denied: "You don't have permission to use this agent. Please contact the administrator.", error_occurred: "Hmm, I couldn't quite process that. Could you say it again?", endChat: "End chat", endConfirm: "End this conversation? Your chat will be cleared.", endYes: "Yes, end", endNo: "No", confirmTitle: "Approval required", confirmApprove: "Approve", confirmReject: "Reject", confirmApproved: "Approved", confirmRejected: "Rejected" },
+    sr: { placeholder: "Unesite poruku…", send: "Pošalji", newChat: "Nov razgovor", stop: "Prekini", interrupted: "Odgovor je prekinut", copy: "Kopiraj", copied: "Kopirano!", download: "Preuzmi", rateUp: "Koristan odgovor", rateDown: "Nije koristan", access_denied: "Nemate pristup ovom agentu. Molimo kontaktirajte administratora.", error_occurred: "Hm, nisam uspeo to da obradim. Možete li da ponovite?", endChat: "Završi", endConfirm: "Završiti razgovor? Vaš chat će biti obrisan.", endYes: "Da, završi", endNo: "Ne", confirmTitle: "Potrebna je potvrda", confirmApprove: "Potvrdi", confirmReject: "Odbaci", confirmApproved: "Potvrđeno", confirmRejected: "Odbačeno" },
+    hr: { placeholder: "Unesite poruku…", send: "Pošalji", newChat: "Novi razgovor", stop: "Prekini", interrupted: "Odgovor je prekinut", copy: "Kopiraj", copied: "Kopirano!", download: "Preuzmi", rateUp: "Koristan odgovor", rateDown: "Nije koristan", access_denied: "Nemate pristup ovom agentu. Kontaktirajte administratora.", error_occurred: "Hm, nisam uspio to obraditi. Možete li ponoviti?" },
+    bs: { placeholder: "Unesite poruku…", send: "Pošalji", newChat: "Novi razgovor", stop: "Prekini", interrupted: "Odgovor je prekinut", copy: "Kopiraj", copied: "Kopirano!", download: "Preuzmi", rateUp: "Koristan odgovor", rateDown: "Nije koristan", access_denied: "Nemate pristup ovom agentu. Kontaktirajte administratora.", error_occurred: "Hm, nisam uspio to obraditi. Možete li ponoviti?" },
+    de: { placeholder: "Nachricht eingeben…", send: "Senden", newChat: "Neuer Chat", stop: "Stoppen", interrupted: "Antwort unterbrochen", copy: "Kopieren", copied: "Kopiert!", download: "Herunterladen", rateUp: "Hilfreich", rateDown: "Nicht hilfreich", access_denied: "Sie haben keinen Zugriff auf diesen Agenten. Bitte kontaktieren Sie den Administrator.", error_occurred: "Hmm, das konnte ich nicht verarbeiten. Können Sie es wiederholen?" },
+    fr: { placeholder: "Écrivez un message…", send: "Envoyer", newChat: "Nouveau chat", stop: "Arrêter", interrupted: "Réponse interrompue", copy: "Copier", copied: "Copié !", download: "Télécharger", rateUp: "Utile", rateDown: "Pas utile", access_denied: "Vous n'avez pas accès à cet agent. Veuillez contacter l'administrateur.", error_occurred: "Hmm, je n'ai pas réussi à traiter cela. Pouvez-vous répéter ?" },
     es: { placeholder: "Escribe un mensaje…", send: "Enviar", newChat: "Nueva conversación", stop: "Detener", interrupted: "Respuesta interrumpida", access_denied: "No tienes permiso para usar este agente. Contacta al administrador.", error_occurred: "Mmm, no pude procesar eso. ¿Puedes repetirlo?" },
     it: { placeholder: "Scrivi un messaggio…", send: "Invia", newChat: "Nuova chat", stop: "Interrompi", interrupted: "Risposta interrotta", access_denied: "Non hai accesso a questo agente. Contatta l'amministratore.", error_occurred: "Hmm, non sono riuscito a elaborarlo. Puoi ripetere?" },
     pt: { placeholder: "Escreva uma mensagem…", send: "Enviar", newChat: "Nova conversa", stop: "Parar", interrupted: "Resposta interrompida", access_denied: "Você não tem acesso a este agente. Contacte o administrador.", error_occurred: "Hmm, não consegui processar isso. Pode repetir?" },
@@ -540,6 +542,7 @@
         activeAgentEl = document.createElement("div");
         activeAgentEl.className = "widget-message agent";
         activeAgentEl.setAttribute("data-author", activeAgentAuthor);
+        if (activeInvocationId) activeAgentEl.setAttribute("data-invocation", activeInvocationId);
         activeAgentEl.innerHTML = THINKING_HTML;
         
         wrapper.appendChild(avatarEl);
@@ -562,6 +565,10 @@
           localStorage.setItem(STORAGE_PREFIX + "_sid", sessionId);
           if (evt.debug_mode !== undefined) debugMode = !!evt.debug_mode;
         }
+
+        // The invocation id identifies the response being rated, and is what ties a
+        // rating to that response's cost and latency on the server.
+        if (evt.invocationId) activeInvocationId = evt.invocationId;
 
         // --- Handle error events (e.g. RBAC access denied) ---
         if (evt.error_code) {
@@ -1317,6 +1324,8 @@
   const COPY_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>';
   const CHECK_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle"><polyline points="20 6 9 17 4 12"></polyline></svg>';
   const DOWNLOAD_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>';
+  const THUMB_UP_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle"><path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3zM7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3"></path></svg>';
+  const THUMB_DOWN_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle"><path d="M10 15v4a3 3 0 0 0 3 3l4-9V2H5.72a2 2 0 0 0-2 1.7l-1.38 9a2 2 0 0 0 2 2.3zm7-13h2.67A2.31 2.31 0 0 1 22 4v7a2.31 2.31 0 0 1-2.33 2H17"></path></svg>';
 
   function _addMessageActions(messageEl) {
     if (!messageEl) return;
@@ -1377,7 +1386,60 @@
     
     actionsContainer.appendChild(copyBtn);
     actionsContainer.appendChild(downloadBtn);
+    _addRatingButtons(actionsContainer, messageEl, s);
     messageEl.appendChild(actionsContainer);
+  }
+
+  function _addRatingButtons(container, messageEl, s) {
+    // Only a response the server can identify is rateable; restored history without an
+    // invocation id simply gets no thumbs rather than a button that fails on click.
+    var invocationId = messageEl.getAttribute("data-invocation");
+    if (!invocationId) return;
+
+    function makeBtn(rating, svg, label) {
+      var btn = document.createElement("button");
+      btn.className = "widget-message-action-btn rate-btn rate-" + rating;
+      btn.title = label;
+      btn.innerHTML = svg;
+      btn.addEventListener("click", function (e) {
+        e.stopPropagation();
+        _submitRating(messageEl, invocationId, rating, container);
+      });
+      return btn;
+    }
+
+    container.appendChild(makeBtn("up", THUMB_UP_SVG, s.rateUp || UI_STRINGS["en"].rateUp));
+    container.appendChild(makeBtn("down", THUMB_DOWN_SVG, s.rateDown || UI_STRINGS["en"].rateDown));
+    _paintRating(container, ratings[invocationId]);
+  }
+
+  function _paintRating(container, rating) {
+    ["up", "down"].forEach(function (r) {
+      var btn = container.querySelector(".rate-" + r);
+      if (btn) btn.classList.toggle("rated", rating === r);
+    });
+  }
+
+  function _submitRating(messageEl, invocationId, rating, container) {
+    // Optimistic: a rating is a courtesy, not a transaction — reflect the click at once
+    ratings[invocationId] = rating;
+    _paintRating(container, rating);
+
+    var payload = {
+      session_id: sessionId,
+      message_id: invocationId,
+      rating: rating,
+    };
+    fetch(`${BASE}/widget/api/feedback`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Widget-Key": API_KEY,
+      },
+      body: JSON.stringify(payload),
+    }).catch(function () {
+      /* the visitor does not need to know; the next rating retries */
+    });
   }
 
   function _fallbackCopy(text, btn, successLabel, normalLabel) {

--- a/templates/dashboard/usage.html
+++ b/templates/dashboard/usage.html
@@ -118,6 +118,90 @@
         </div>
     </div>
 
+    <!-- Response quality: did it help, how long did it take, what did a conversation cost -->
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-3">
+            <div class="flex items-center">
+                <div class="w-10 h-10 rounded-full bg-emerald-100 dark:bg-emerald-900 flex items-center justify-center">
+                    <i class="fas fa-thumbs-up text-sm text-emerald-600 dark:text-emerald-400"></i>
+                </div>
+                <div class="ml-3 min-w-0">
+                    <h3 class="text-xs font-medium text-gray-500 dark:text-gray-400">Satisfaction</h3>
+                    <p class="text-lg font-bold text-gray-900 dark:text-white" id="satisfactionRate">
+                        {% if stats.satisfaction and stats.satisfaction.rate_pct is not none %}{{ stats.satisfaction.rate_pct }}%{% else %}—{% endif %}
+                    </p>
+                    <p class="text-xs text-gray-500 dark:text-gray-400" id="satisfactionSample">
+                        {% if stats.satisfaction %}{{ stats.satisfaction.rated }} of {{ stats.satisfaction.responses }} rated{% endif %}
+                    </p>
+                </div>
+            </div>
+        </div>
+
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-3">
+            <div class="flex items-center">
+                <div class="w-10 h-10 rounded-full bg-sky-100 dark:bg-sky-900 flex items-center justify-center">
+                    <i class="fas fa-stopwatch text-sm text-sky-600 dark:text-sky-400"></i>
+                </div>
+                <div class="ml-3 min-w-0">
+                    <h3 class="text-xs font-medium text-gray-500 dark:text-gray-400">Response Latency</h3>
+                    <p class="text-lg font-bold text-gray-900 dark:text-white" id="latencyP50">
+                        {% if stats.latency %}{{ "%.1f"|format(stats.latency.p50_ms / 1000) }}s{% else %}—{% endif %}
+                        <span class="text-xs font-normal text-gray-500 dark:text-gray-400">p50</span>
+                    </p>
+                    <p class="text-xs text-gray-500 dark:text-gray-400" id="latencyP95">
+                        {% if stats.latency %}p95 {{ "%.1f"|format(stats.latency.p95_ms / 1000) }}s · {{ stats.latency.samples }} responses{% if stats.latency.unfinished %} · {{ stats.latency.unfinished }} unfinished{% endif %}{% endif %}
+                    </p>
+                </div>
+            </div>
+        </div>
+
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-3">
+            <div class="flex items-center">
+                <div class="w-10 h-10 rounded-full bg-violet-100 dark:bg-violet-900 flex items-center justify-center">
+                    <i class="fas fa-comments text-sm text-violet-600 dark:text-violet-400"></i>
+                </div>
+                <div class="ml-3 min-w-0">
+                    <h3 class="text-xs font-medium text-gray-500 dark:text-gray-400">Tokens per Conversation</h3>
+                    <p class="text-lg font-bold text-gray-900 dark:text-white" id="tokensPerConversation">
+                        {% if stats.conversations %}{{ "{:,}".format(stats.conversations.avg_tokens) }}{% else %}—{% endif %}
+                    </p>
+                    <p class="text-xs text-gray-500 dark:text-gray-400" id="conversationSample">
+                        {% if stats.conversations %}median {{ "{:,}".format(stats.conversations.median_tokens) }} · {{ stats.conversations.count }} conversations{% endif %}
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {% if stats.satisfaction and stats.satisfaction.per_agent %}
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
+        <h3 class="text-sm font-semibold text-gray-900 dark:text-white mb-2">Satisfaction by Agent</h3>
+        <div class="overflow-x-auto">
+            <table class="w-full text-xs">
+                <thead>
+                    <tr class="text-left text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700">
+                        <th class="px-2 py-1 font-medium">Agent</th>
+                        <th class="px-2 py-1 font-medium">Helpful</th>
+                        <th class="px-2 py-1 font-medium">Not helpful</th>
+                        <th class="px-2 py-1 font-medium">Rate</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
+                    {% for row in stats.satisfaction.per_agent %}
+                    <tr class="text-gray-700 dark:text-gray-300">
+                        <td class="px-2 py-1">{{ row.agent }}</td>
+                        <td class="px-2 py-1 text-emerald-600 dark:text-emerald-400">{{ row.up }}</td>
+                        <td class="px-2 py-1 text-red-600 dark:text-red-400">{{ row.down }}</td>
+                        <td class="px-2 py-1">{% if row.rate_pct is not none %}{{ row.rate_pct }}%{% else %}—{% endif %}
+                            <span class="text-gray-400">({{ row.rated }})</span></td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+    {% endif %}
+
     <!-- Charts Row 1 -->
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
         <!-- Daily Usage Chart -->

--- a/templates/dashboard/workroom.html
+++ b/templates/dashboard/workroom.html
@@ -3,7 +3,7 @@
 {% block title %}Work Room - MATE{% endblock %}
 
 {% block extra_head %}
-<link rel="stylesheet" href="/static/css/widget/chat.css?v=5">
+<link rel="stylesheet" href="/static/css/widget/chat.css?v=7">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.32.6/ace.min.js" defer></script>
 <style>
     /* ── Work Room layout (redesign tokens) ───────────────── */

--- a/templates/standalone/chat.html
+++ b/templates/standalone/chat.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{{ agent_name }} — MATE</title>
-  <link rel="stylesheet" href="/static/css/widget/chat.css?v=5">
+  <link rel="stylesheet" href="/static/css/widget/chat.css?v=7">
   <style>
     /* Standalone overrides — slightly wider container on desktop */
     @media (min-width: 768px) {
@@ -55,7 +55,7 @@
     // Standalone mode — talks directly to local ADK endpoints
     window.STANDALONE_AGENT_NAME = "{{ agent_name }}";
   </script>
-  <script src="/static/js/standalone/chat.js?v=5"></script>
+  <script src="/static/js/standalone/chat.js?v=6"></script>
 </body>
 
 </html>

--- a/templates/widget/chat.html
+++ b/templates/widget/chat.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Chat</title>
-  <link rel="stylesheet" href="/static/css/widget/chat.css?v=6">
+  <link rel="stylesheet" href="/static/css/widget/chat.css?v=7">
 </head>
 
 <body>
@@ -59,7 +59,7 @@
     window.WIDGET_AGENT_NAME = "{{ agent_name }}";
     window.WIDGET_CONFIG = {{ widget_config | safe }};
   </script>
-  <script src="/static/js/widget/chat.js?v=10"></script>
+  <script src="/static/js/widget/chat.js?v=11"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Implements #22. Three commits, reviewable in order — each adds a signal the next one builds on.

## What the issue asked for, and what was actually there

Verifying #22 against `main` turned up three gaps that changed what was buildable:

- **There is no cost.** No per-model token pricing exists anywhere in MATE. `shared/utils/wizard/pricing.py` is subscription tiers and says plainly there is no billing. So "cost per conversation" ships as **tokens** per conversation; the acceptance criterion's wording implied a money figure that cannot be produced.
- **There is no latency.** `token_usage_logs` has no duration column. `trace_spans.duration_ms` needs `OTEL_TRACING_ENABLED`, exists only on ADK, and times a single model call rather than a response. The Prometheus histogram on the auth server stops when the `StreamingResponse` object is returned, so it never sees a stream finish.
- **There is no per-message identity.** ADK wrote `request_id = uuid4()` per model call, so a response's several calls could not be grouped at all. LangGraph already used the invocation id.

## Where the measurement had to go

Eight surfaces produce an agent response and all converge on the same Runner in the agent process — but **only `/run_sse` and A2A reach it through the auth server's proxy**. The widget, `/v1/chat/completions`, MCP, triggers, Slack and evals each open their own client straight to port 8001. Measuring in the HTTP layer would have missed six of the eight.

So it sits at the runtime's invocation boundary: a `MetricsPlugin` implementing only `before_run`/`after_run` for ADK, and `run_sse_stream` for LangGraph, which has no A2A or MCP of its own. The plugin is registered unconditionally rather than behind `MATE_PLUGINS_ENABLED`, and implements no model callbacks, so it cannot double-execute against the per-agent wiring.

## `d3c4da3` — record how long each response takes

Rows are **opened** before the run and **closed** after it. Driving both engines is what forced this: ADK calls its after-run hook after the event loop rather than in a `finally` (`google/adk/runners.py:1413`), so under a single-write design a failed invocation recorded nothing at all — the first live probe returned 200 with an empty table. A row left `RUNNING` is now a response that errored or never finished.

LangGraph closes its row from a `finally` and so records a duration and `ERROR` even on failure. The asymmetry is deliberate: ADK's `retry_config` means one failed model call is not necessarily a failed response.

`token_usage_logs.request_id` now carries the ADK invocation id, which is what makes tokens per conversation groupable.

## `f4bb513` — thumbs up/down

Ratings are keyed by `(session_id, invocation_id)` with a unique constraint, so re-rating changes the row — the satisfaction rate counts responses, not clicks.

The public endpoint sits behind the widget key like the chat endpoint and takes the agent and project **from the key, not the body**: verified against a running server, a request carrying `agent_name: "someone_else"` is still recorded under the key's agent. The path is added to the rate-limit middleware, which matched only `run_sse` and widget chat, so the one endpoint reachable with a public credential would otherwise have been unthrottled.

The buttons join the copy/download row both chats already build and use the existing `UI_STRINGS` localisation. Only a message carrying an invocation id gets them.

## `ed68b4f` — the numbers

Satisfaction is shown with its denominator (`4 of 11 rated`) because ratings only come from two surfaces; a bare percentage over a thin self-selected sample reads as far more than it is. With no ratings the panel shows a dash, not 0%.

Latency percentiles cover responses that finished and count unfinished invocations separately rather than folding them in as zero. Only interactive origins are included — verified with seeded data, a 240s trigger alongside chat responses leaves p95 at 8.8s instead of defining it. Percentiles are nearest-rank in Python; SQLite has no `PERCENTILE_CONT`.

## Verification

645 tests pass, 51 of them new. Migrations V027 and V028 apply to an empty **SQLite and PostgreSQL 16** (28/28), including the unique constraint and the `updated_at` trigger.

Driven live against a running server:

- **both engines** — ADK leaves a `RUNNING` row on a failed invocation, LangGraph closes its row with `ERROR` and a duration
- **feedback end to end in a browser** on the LangGraph runtime — the bubble carries the invocation id, the thumbs render, a click lights the button and the row lands in the database
- **the endpoint directly** — changing a rating updates in place, a bad rating is 400, no key is 401, a spoofed agent in the body is ignored
- **the usage page** with seeded data — `71.4% · 7 of 11 rated`, `1.5s p50 · p95 8.8s · 9 responses · 2 unfinished`, `1,190 tokens · median 380 · 2 conversations`

## Not verified

The ADK half of the SSE wiring for the thumbs could not be checked in a browser: with no usable LLM key its error path renders a generic bubble carrying no invocation id, so the controls correctly do not appear. That half is covered by unit tests only — worth clicking a thumb in the Workroom on a deployment where the keys work.

No successful agent response was measurable here at all (outbound LLM calls are blocked), so every live latency figure came from a failed or seeded call.

## Out of scope, found along the way

- **`/v1/chat/completions` reports cumulative usage** — `server/openai_routes.py:234` and `:298` sum every row for the session, so each turn of a conversation reports a larger `usage` than the last. Adjacent bug, worth its own issue.
- **The MCP endpoints have no authentication** (`shared/utils/mcp/agent_mcp_server.py:26`) and shadow the proxy catch-all — an unauthenticated path to an agent.
- Slack ratings would need Block Kit elements arriving on `POST /slack/interactions`.
- p99, PDF export, statistical agent comparison, inferred completion rate — excluded by the issue itself.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ToCUNy2SqwvfTq4a6xfSk1)_