### PR TITLE
Let the latency panel switch between traffic origins

### DIFF
--- a/shared/test/test_usage_quality_stats.py
+++ b/shared/test/test_usage_quality_stats.py
@@ -205,6 +205,63 @@ class TestQualityStats(unittest.TestCase):
         self.assertEqual(stats["latency"]["samples"], 0)
         self.assertIsNone(stats["satisfaction"]["rate_pct"])
 
+    # --- origin filter ---------------------------------------------------
+
+    def _stats_for(self, origin):
+        session = self.Session()
+        try:
+            return self.server._get_quality_stats(
+                session, self.start, self.now,
+                self.server.resolve_origins(origin))
+        finally:
+            session.close()
+
+    def test_filter_selects_background_work(self):
+        # The point of the filter: ask how long the scheduled jobs actually take
+        self._response(500, origin="chat", minutes_ago=1)
+        self._response(240000, origin="trigger", minutes_ago=2)
+        latency = self._stats_for("trigger")["latency"]
+        self.assertEqual(latency["samples"], 1)
+        self.assertEqual(latency["p50_ms"], 240000)
+
+    def test_all_includes_every_origin(self):
+        self._response(500, origin="chat", minutes_ago=1)
+        self._response(240000, origin="trigger", minutes_ago=2)
+        self._response(900, origin="eval", minutes_ago=3)
+        self.assertEqual(self._stats_for("all")["latency"]["samples"], 3)
+
+    def test_unknown_filter_falls_back_to_interactive(self):
+        # It arrives from a query string; a typo must not blank the panel
+        self._response(500, origin="chat", minutes_ago=1)
+        self._response(240000, origin="trigger", minutes_ago=2)
+        latency = self._stats_for("nonsense")["latency"]
+        self.assertEqual(latency["samples"], 1)
+        self.assertEqual(latency["p50_ms"], 500)
+
+    def test_selected_origins_are_reported_back(self):
+        # So the panel can say which traffic the number describes
+        self.assertEqual(self._stats_for("trigger")["latency"]["origins"], ["trigger"])
+        self.assertEqual(sorted(self._stats_for("interactive")["latency"]["origins"]),
+                         ["api", "chat"])
+
+    def test_satisfaction_denominator_ignores_the_filter(self):
+        # response_feedback has no origin, and ratings only come from chat surfaces —
+        # chat ratings over a trigger denominator would be a meaningless ratio
+        self._response(500, origin="chat", minutes_ago=1)
+        self._response(240000, origin="trigger", minutes_ago=2)
+        self._rating("up")
+        for origin in ("interactive", "trigger", "all"):
+            s = self._stats_for(origin)["satisfaction"]
+            self.assertEqual(s["responses"], 1, origin)
+            self.assertEqual(s["rated"], 1, origin)
+
+    def test_usage_stats_passes_the_filter_through(self):
+        self._response(500, origin="chat", minutes_ago=1)
+        self._response(240000, origin="trigger", minutes_ago=2)
+        stats = self.server._get_usage_stats(
+            days=7, origins=self.server.resolve_origins("trigger"))
+        self.assertEqual(stats["latency"]["p50_ms"], 240000)
+
     def test_quality_panels_reach_the_usage_stats(self):
         self._response(700, minutes_ago=1)
         self._rating("up")

--- a/shared/utils/dashboard/dashboard_server.py
+++ b/shared/utils/dashboard/dashboard_server.py
@@ -207,8 +207,12 @@ class DashboardServer:
 
         return last_text.strip()
 
-    def _get_usage_stats(self, days: int = 7) -> Dict[str, Any]:
-        """Get usage statistics from database."""
+    def _get_usage_stats(self, days: int = 7,
+                         origins: Optional[tuple] = None) -> Dict[str, Any]:
+        """Get usage statistics from database.
+
+        `origins` narrows the latency panel only; None keeps the interactive default.
+        """
         if not self.db_client:
             return {
                 "total_requests": 0,
@@ -299,7 +303,7 @@ class DashboardServer:
                 'hourly_usage': hourly_data,
                 'database_info': self._get_database_info()
             }
-            result.update(self._get_quality_stats(session, start_date, end_date))
+            result.update(self._get_quality_stats(session, start_date, end_date, origins))
             return result
         except Exception as e:
             print(f"Error getting usage stats: {e}")
@@ -323,19 +327,49 @@ class DashboardServer:
     # scheduled job took. The rest stays in the table and is reachable by filter.
     INTERACTIVE_ORIGINS = ('chat', 'api')
 
-    def _get_quality_stats(self, session, start_date, end_date) -> Dict[str, Any]:
+    # What the latency panel's dropdown offers. 'interactive' is the default because
+    # it answers "how long did a person wait"; the others are for diagnosing
+    # background work that would otherwise be invisible.
+    ORIGIN_FILTERS = {
+        'interactive': ('chat', 'api'),
+        'chat': ('chat',),
+        'api': ('api',),
+        'trigger': ('trigger',),
+        'slack': ('slack',),
+        'eval': ('eval',),
+        'all': ('chat', 'api', 'trigger', 'slack', 'eval'),
+    }
+
+    @classmethod
+    def resolve_origins(cls, origin: Optional[str]) -> tuple:
+        """Map a filter name to the origins it covers.
+
+        An unknown value falls back to interactive rather than erroring: this arrives
+        from a query string, and a typo should not blank the panel.
+        """
+        return cls.ORIGIN_FILTERS.get((origin or '').strip().lower(),
+                                      cls.INTERACTIVE_ORIGINS)
+
+    def _get_quality_stats(self, session, start_date, end_date,
+                           origins: Optional[tuple] = None) -> Dict[str, Any]:
         """Satisfaction, response latency and tokens per conversation.
 
         Kept apart from the token panels above: these read agent_responses and
         response_feedback, and a failure in any of them must not blank the whole
         usage page.
+
+        `origins` narrows the latency panel only. Satisfaction keeps the interactive
+        denominator whatever is selected: response_feedback has no origin column, and
+        ratings only ever come from the widget and the workroom — showing chat
+        ratings over a trigger denominator would be a meaningless ratio.
         """
         from sqlalchemy import func
 
         empty = {
             'satisfaction': {'up': 0, 'down': 0, 'rated': 0, 'rate_pct': None,
                              'responses': 0, 'per_agent': []},
-            'latency': {'p50_ms': 0, 'p95_ms': 0, 'samples': 0, 'unfinished': 0},
+            'latency': {'origins': list(origins or self.INTERACTIVE_ORIGINS),
+                        'p50_ms': 0, 'p95_ms': 0, 'samples': 0, 'unfinished': 0},
             'conversations': {'count': 0, 'avg_tokens': 0, 'median_tokens': 0},
         }
         try:
@@ -397,13 +431,14 @@ class DashboardServer:
             stats['satisfaction'] = empty['satisfaction']
 
         # --- Latency ------------------------------------------------------
+        selected_origins = tuple(origins or self.INTERACTIVE_ORIGINS)
         try:
             durations = [
                 int(r[0]) for r in session.query(AgentResponse.duration_ms).filter(
                     AgentResponse.started_at >= start_date,
                     AgentResponse.started_at <= end_date,
                     AgentResponse.duration_ms.isnot(None),
-                    AgentResponse.origin.in_(self.INTERACTIVE_ORIGINS),
+                    AgentResponse.origin.in_(selected_origins),
                 ).all() if r[0] is not None
             ]
             durations.sort()
@@ -413,10 +448,11 @@ class DashboardServer:
                 AgentResponse.started_at >= start_date,
                 AgentResponse.started_at <= end_date,
                 AgentResponse.duration_ms.is_(None),
-                AgentResponse.origin.in_(self.INTERACTIVE_ORIGINS),
+                AgentResponse.origin.in_(selected_origins),
             ).scalar() or 0
 
             stats['latency'] = {
+                'origins': list(selected_origins),
                 'p50_ms': self._percentile(durations, 0.50),
                 'p95_ms': self._percentile(durations, 0.95),
                 'samples': len(durations),
@@ -2786,10 +2822,10 @@ class DashboardServer:
             })
 
         @self.app.get("/dashboard/usage", response_class=HTMLResponse, tags=["Dashboard - Pages"])
-        async def dashboard_usage(request: Request, days: int = 30, view: str = "analytics", username: str = Depends(self._get_auth_user_dependency)):
+        async def dashboard_usage(request: Request, days: int = 30, view: str = "analytics", origin: str = "interactive", username: str = Depends(self._get_auth_user_dependency)):
             """Dashboard usage page"""
             is_admin = self._get_is_admin(request)
-            stats = self._get_usage_stats(days)
+            stats = self._get_usage_stats(days, self.resolve_origins(origin))
             logs = self._get_token_usage_logs(24, limit=1000) if view == "logs" else {"logs": []}
             # Non-admin users see only their own usage
             current_user_id = username
@@ -2801,6 +2837,7 @@ class DashboardServer:
                 "logs": logs.get("logs", []) if isinstance(logs, dict) else [],
                 "days": days,
                 "view": view,
+                "origin": origin if origin in self.ORIGIN_FILTERS else "interactive",
                 "is_admin": is_admin,
                 "current_user_id": current_user_id,
             })
@@ -3290,9 +3327,9 @@ class DashboardServer:
 
         # API Endpoints for Dashboard
         @self.app.get("/dashboard/api/stats", tags=["Dashboard - Usage Analytics"])
-        async def get_stats(request: Request, username: str = Depends(self._get_auth_user_dependency), days: int = 7):
-            """Get usage statistics."""
-            return self._get_usage_stats(days)
+        async def get_stats(request: Request, username: str = Depends(self._get_auth_user_dependency), days: int = 7, origin: str = "interactive"):
+            """Get usage statistics. `origin` narrows the latency panel only."""
+            return self._get_usage_stats(days, self.resolve_origins(origin))
 
         @self.app.get("/dashboard/api/usage/logs", tags=["Dashboard - Usage Analytics"])
         async def get_usage_logs_api(

--- a/templates/dashboard/usage.html
+++ b/templates/dashboard/usage.html
@@ -142,8 +142,20 @@
                 <div class="w-10 h-10 rounded-full bg-sky-100 dark:bg-sky-900 flex items-center justify-center">
                     <i class="fas fa-stopwatch text-sm text-sky-600 dark:text-sky-400"></i>
                 </div>
-                <div class="ml-3 min-w-0">
-                    <h3 class="text-xs font-medium text-gray-500 dark:text-gray-400">Response Latency</h3>
+                <div class="ml-3 min-w-0 flex-1">
+                    <div class="flex items-center justify-between gap-2">
+                        <h3 class="text-xs font-medium text-gray-500 dark:text-gray-400">Response Latency</h3>
+                        <select id="originSelect" onchange="updateOriginFilter()" title="Which traffic the percentiles cover"
+                                class="border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded px-1 py-0.5 text-xs">
+                            <option value="interactive" {% if origin == "interactive" %}selected{% endif %}>Interactive</option>
+                            <option value="chat" {% if origin == "chat" %}selected{% endif %}>Chat</option>
+                            <option value="api" {% if origin == "api" %}selected{% endif %}>API</option>
+                            <option value="trigger" {% if origin == "trigger" %}selected{% endif %}>Triggers</option>
+                            <option value="slack" {% if origin == "slack" %}selected{% endif %}>Slack</option>
+                            <option value="eval" {% if origin == "eval" %}selected{% endif %}>Evals</option>
+                            <option value="all" {% if origin == "all" %}selected{% endif %}>All</option>
+                        </select>
+                    </div>
                     <p class="text-lg font-bold text-gray-900 dark:text-white" id="latencyP50">
                         {% if stats.latency %}{{ "%.1f"|format(stats.latency.p50_ms / 1000) }}s{% else %}—{% endif %}
                         <span class="text-xs font-normal text-gray-500 dark:text-gray-400">p50</span>
@@ -646,6 +658,14 @@
 
     function closeModal(modalId) {
         document.getElementById(modalId).classList.add('hidden');
+    }
+
+    function updateOriginFilter() {
+        // Same shape as updateTimeRange: reload with the parameter, keeping the
+        // day range and the current view so the selection is not silently reset.
+        const url = new URL(window.location);
+        url.searchParams.set('origin', document.getElementById('originSelect').value);
+        window.location.href = url.toString();
     }
 
     async function updateTimeRange() {


### PR DESCRIPTION
Follow-up to #66, which is merged. One commit.

## Why

The percentiles added in #66 are hardcoded to `origin IN ('chat', 'api')`. That is the right default — a scheduled trigger taking four minutes must not define the p95 a customer reads — but it left background work **invisible rather than filterable**. There was no way to ask how long the triggers actually take, even though the rows are sitting in `agent_responses`.

## What changed

The latency panel gains a select: **Interactive** (default), Chat, API, Triggers, Slack, Evals, All. It reloads with an `origin` query parameter exactly the way the existing time-range control does, preserving `days` and `view`. An unrecognised value falls back to interactive rather than erroring — it arrives from a query string, and a typo should not blank the panel.

`_get_quality_stats` takes an `origins` tuple instead of reading the constant directly; `_get_usage_stats(days, origins=None)` passes it through, so the other caller is untouched. `/dashboard/usage` and `/dashboard/api/stats` both accept the parameter.

## The filter deliberately moves latency only

`response_feedback` has no origin column, and ratings only ever arrive from the widget and the workroom. Filtering to `trigger` would show chat ratings over a trigger denominator — a ratio that means nothing. Tokens per conversation is unaffected for the same reason: `token_usage_logs` has no origin either.

A test pins this: the satisfaction denominator stays put across `interactive`, `trigger` and `all`.

## Verification

651 tests pass, 6 of them new.

Against a running server with seeded rows:

| `origin` | result |
|---|---|
| `interactive` | p50 1.5s, p95 8.8s, 9 samples |
| `trigger` | p50 240s, p95 240s, 1 sample |
| `all` | p50 1.5s, **p95 240s**, 10 samples |
| `nonsense` | falls back to the interactive figures |

Satisfaction reads `7 of 11 rated` in every case.

Driven in a browser: the select navigates to `?days=7&origin=trigger`, the panel moves from `1.5s p50` to `240.0s p50`, the select keeps its value and the day range survives.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ToCUNy2SqwvfTq4a6xfSk1)_