### PR TITLE
Clone an agent hierarchy into another project (#19)

### DIFF
--- a/shared/test/test_agent_clone.py
+++ b/shared/test/test_agent_clone.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""
+Unit tests for cloning an agent tree into another project (#19).
+
+The operation is insert-only: its central promise is that the source hierarchy
+is never modified, whatever happens. The other load-bearing parts are the name
+rewrite — agent names are globally unique, so every clone is renamed, and
+in-tree references in text fields must follow — and the tree walk, which has to
+handle multi-parent sub-agents without duplicating or escaping the tree.
+"""
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from shared.utils.models import (
+    AgentConfig, AgentFileSearchStore, AuditLog, Base, FileSearchStore,
+    MemoryBlock, Project,
+)
+from shared.utils.dashboard.dashboard_server import DashboardServer
+
+
+class TestCloneAgentTree(unittest.TestCase):
+
+    def setUp(self):
+        self.engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(self.engine)
+        self.Session = sessionmaker(bind=self.engine)
+
+        self.mock_db_client = MagicMock()
+        self.mock_db_client.get_session.side_effect = lambda: self.Session()
+        self.mock_db_client.is_connected.return_value = True
+        self.patcher = patch('shared.utils.database_client.get_database_client',
+                             return_value=self.mock_db_client)
+        self.patcher.start()
+        self.audit_patcher = patch('shared.utils.audit_service.get_database_client',
+                                   return_value=self.mock_db_client)
+        self.audit_patcher.start()
+
+        from fastapi import FastAPI
+        project_root = Path(os.path.dirname(os.path.dirname(
+            os.path.dirname(os.path.abspath(__file__)))))
+        self.server = DashboardServer(FastAPI(), project_root)
+        self.server.db_client = self.mock_db_client
+        # Folder creation writes to the real agents/ directory — keep it off disk
+        self.server._copy_template_agent = MagicMock(
+            return_value={"success": True, "skipped": False})
+
+        session = self.Session()
+        session.add(Project(id=1, name="Source"))
+        session.add(Project(id=2, name="Acme Support"))
+        session.add(AgentConfig(name="support_root", type="llm", project_id=1,
+                                instruction="Route billing to support_billing, tech to support_tech."))
+        session.add(AgentConfig(name="support_billing", type="llm", project_id=1,
+                                parent_agents='["support_root"]'))
+        # Two in-tree parents — must be collected once, both parents mapped
+        session.add(AgentConfig(name="support_tech", type="llm", project_id=1,
+                                parent_agents='["support_root", "support_billing"]'))
+        session.add(AgentConfig(name="other_root", type="llm", project_id=1))
+        session.commit()
+        session.close()
+
+    def tearDown(self):
+        self.patcher.stop()
+        self.audit_patcher.stop()
+        self.engine.dispose()
+
+    def _clone(self, **kwargs):
+        defaults = dict(root_name="support_root", target_project_id=2,
+                        suffix="_acme", changed_by="tester")
+        defaults.update(kwargs)
+        return self.server._clone_agent_tree(**defaults)
+
+    def _agents(self, project_id):
+        session = self.Session()
+        try:
+            return {a.name: a for a in session.query(AgentConfig).filter(
+                AgentConfig.project_id == project_id).all()}
+        finally:
+            session.close()
+
+    def test_clones_the_whole_tree_with_rewritten_parents(self):
+        result = self._clone()
+        self.assertTrue(result.get("success"), result)
+        self.assertEqual(result["new_root"], "support_root_acme")
+
+        clones = self._agents(2)
+        self.assertEqual(set(clones), {"support_root_acme", "support_billing_acme",
+                                       "support_tech_acme"})
+        self.assertEqual(clones["support_root_acme"].get_parent_agents(), [])
+        self.assertEqual(clones["support_billing_acme"].get_parent_agents(),
+                         ["support_root_acme"])
+        self.assertEqual(clones["support_tech_acme"].get_parent_agents(),
+                         ["support_root_acme", "support_billing_acme"])
+
+    def test_out_of_tree_agents_are_not_cloned(self):
+        self._clone()
+        self.assertNotIn("other_root_acme", self._agents(2))
+
+    def test_out_of_tree_parent_is_dropped(self):
+        # The clone must form its own tree, never attach into the source hierarchy
+        session = self.Session()
+        session.add(AgentConfig(name="support_shared", type="llm", project_id=1,
+                                parent_agents='["support_root", "other_root"]'))
+        session.commit()
+        session.close()
+        self._clone()
+        clones = self._agents(2)
+        self.assertEqual(clones["support_shared_acme"].get_parent_agents(),
+                         ["support_root_acme"])
+
+    def test_source_rows_are_untouched(self):
+        before = {n: (a.project_id, a.parent_agents, a.instruction)
+                  for n, a in self._agents(1).items()}
+        self._clone()
+        after = {n: (a.project_id, a.parent_agents, a.instruction)
+                 for n, a in self._agents(1).items()}
+        self.assertEqual(before, after)
+
+    def test_instruction_references_follow_the_rename(self):
+        self._clone()
+        instruction = self._agents(2)["support_root_acme"].instruction
+        self.assertIn("support_billing_acme", instruction)
+        self.assertIn("support_tech_acme", instruction)
+        self.assertNotIn("support_billing,", instruction)
+
+    def test_nested_names_survive_the_rewrite(self):
+        # "support" is a prefix of "support_billing": sequential .replace would
+        # corrupt the longer name mid-string. The word-boundary single pass must not.
+        session = self.Session()
+        session.add(AgentConfig(name="support", type="llm", project_id=1,
+                                instruction="use support_billing then support"))
+        session.add(AgentConfig(name="support_billing2", type="llm", project_id=1,
+                                parent_agents='["support"]'))
+        session.commit()
+        session.close()
+        result = self._clone(root_name="support")
+        self.assertTrue(result.get("success"), result)
+        instruction = self._agents(2)["support_acme"].instruction
+        self.assertEqual(instruction, "use support_billing then support_acme")
+
+    def test_name_collision_bumps_the_suffix(self):
+        session = self.Session()
+        session.add(AgentConfig(name="support_root_acme", type="llm", project_id=2))
+        session.commit()
+        session.close()
+        result = self._clone()
+        self.assertTrue(result.get("success"), result)
+        self.assertEqual(result["new_root"], "support_root_acme_2")
+        # The colliding agent is not touched
+        self.assertIsNone(self._agents(2)["support_root_acme"].instruction)
+
+    def test_folder_created_for_the_cloned_root_only(self):
+        self._clone()
+        self.server._copy_template_agent.assert_called_once_with("support_root_acme")
+
+    def test_non_root_agent_is_rejected(self):
+        result = self._clone(root_name="support_billing")
+        self.assertEqual(result.get("status_code"), 400)
+        self.assertEqual(self._agents(2), {})
+
+    def test_unknown_target_project_is_rejected(self):
+        result = self._clone(target_project_id=99)
+        self.assertEqual(result.get("status_code"), 404)
+
+    def test_empty_suffix_is_rejected(self):
+        result = self._clone(suffix="   ")
+        self.assertEqual(result.get("status_code"), 400)
+
+    def test_memory_blocks_copied_and_existing_labels_kept(self):
+        session = self.Session()
+        session.add(MemoryBlock(project_id=1, label="faq", value="source faq"))
+        session.add(MemoryBlock(project_id=1, label="policies", value="source policies"))
+        session.add(MemoryBlock(project_id=2, label="faq", value="target faq"))
+        session.commit()
+        session.close()
+        result = self._clone(include_memory_blocks=True)
+        self.assertEqual(result["memory_blocks_copied"], 1)
+        session = self.Session()
+        target_blocks = {b.label: b.value for b in session.query(MemoryBlock).filter(
+            MemoryBlock.project_id == 2).all()}
+        session.close()
+        # The pre-existing target block wins; only the missing label was copied
+        self.assertEqual(target_blocks, {"faq": "target faq",
+                                         "policies": "source policies"})
+
+    def test_memory_blocks_not_copied_by_default(self):
+        session = self.Session()
+        session.add(MemoryBlock(project_id=1, label="faq", value="v"))
+        session.commit()
+        session.close()
+        result = self._clone()
+        self.assertEqual(result["memory_blocks_copied"], 0)
+
+    def test_file_search_assignments_share_the_store(self):
+        session = self.Session()
+        session.add(FileSearchStore(id=5, project_id=1, store_name="stores/abc",
+                                    display_name="docs"))
+        session.add(AgentFileSearchStore(agent_name="support_billing", store_id=5,
+                                         is_primary=True))
+        session.commit()
+        session.close()
+        result = self._clone(include_file_search=True)
+        self.assertEqual(result["file_search_assigned"], 1)
+        session = self.Session()
+        row = session.query(AgentFileSearchStore).filter(
+            AgentFileSearchStore.agent_name == "support_billing_acme").one()
+        session.close()
+        # Same store — the remote Gemini store and its documents are shared
+        self.assertEqual(row.store_id, 5)
+        self.assertTrue(row.is_primary)
+
+    def test_clone_is_audited(self):
+        self._clone()
+        session = self.Session()
+        rows = session.query(AuditLog).filter(AuditLog.action == "agent.clone").all()
+        session.close()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0].resource_id, "support_root")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/shared/utils/audit_service.py
+++ b/shared/utils/audit_service.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 ACTION_AGENT_CREATE = "agent.create"
 ACTION_AGENT_UPDATE = "agent.update"
 ACTION_AGENT_DELETE = "agent.delete"
+ACTION_AGENT_CLONE = "agent.clone"
 ACTION_USER_CREATE = "user.create"
 ACTION_USER_UPDATE = "user.update"
 ACTION_USER_DELETE = "user.delete"

--- a/shared/utils/dashboard/dashboard_server.py
+++ b/shared/utils/dashboard/dashboard_server.py
@@ -1756,6 +1756,202 @@ class DashboardServer:
         finally:
             session.close()
     
+    def _clone_agent_tree(self, root_name: str, target_project_id: int, suffix: str,
+                          include_memory_blocks: bool = False,
+                          include_file_search: bool = False,
+                          changed_by: str = None) -> Dict[str, Any]:
+        """Deep-copy a root agent and its sub-agent tree into another project.
+
+        Insert-only by design: the "without corrupting the source" acceptance
+        criterion of #19 holds because no source row is ever updated. Agent names
+        are globally unique, so every clone gets `name + suffix` (bumped with _2/_3
+        on collision), and in-tree name references in text fields follow the rename.
+        """
+        import re
+
+        suffix = (suffix or "").strip()
+        if not suffix:
+            return {"error": "suffix is required", "status_code": 400}
+
+        if not self.db_client:
+            return {"error": "Database connection failed", "status_code": 500}
+        session = self.db_client.get_session()
+        if not session:
+            return {"error": "Database connection failed", "status_code": 500}
+
+        try:
+            root = session.query(self.AgentConfig).filter(
+                self.AgentConfig.name == root_name).first()
+            if not root:
+                return {"error": f"Agent '{root_name}' not found", "status_code": 404}
+            if root.get_parent_agents():
+                return {"error": f"'{root_name}' is not a root agent — clone starts from the top of a tree",
+                        "status_code": 400}
+            target = session.query(self.Project).filter(
+                self.Project.id == target_project_id).first()
+            if not target:
+                return {"error": f"Target project {target_project_id} not found", "status_code": 404}
+
+            # Walk the tree in the source project. One query, then BFS in Python —
+            # a sub-agent reachable through two in-tree parents is collected once.
+            project_agents = session.query(self.AgentConfig).filter(
+                self.AgentConfig.project_id == root.project_id).all()
+            by_name = {a.name: a for a in project_agents}
+            tree_order = [root.name]
+            seen = {root.name}
+            frontier = {root.name}
+            while frontier:
+                next_frontier = set()
+                for agent in project_agents:
+                    if agent.name in seen:
+                        continue
+                    if any(p in frontier or p in seen for p in agent.get_parent_agents()):
+                        tree_order.append(agent.name)
+                        seen.add(agent.name)
+                        next_frontier.add(agent.name)
+                frontier = next_frontier
+
+            # New names: suffix everyone, bump on collision against the DB and
+            # against names assigned earlier in this very clone.
+            def _name_taken(candidate: str) -> bool:
+                return session.query(self.AgentConfig.id).filter(
+                    self.AgentConfig.name == candidate).first() is not None
+
+            name_map: Dict[str, str] = {}
+            for old_name in tree_order:
+                candidate = f"{old_name}{suffix}"
+                bump = 1
+                while _name_taken(candidate) or candidate in name_map.values():
+                    bump += 1
+                    candidate = f"{old_name}{suffix}_{bump}"
+                name_map[old_name] = candidate
+
+            # In-tree references inside text fields follow the rename. A single-pass
+            # regex with word boundaries, longest name first: sequential .replace (as
+            # sub_names in _import_template does) corrupts nested names — renaming
+            # "support" would also hit the middle of an already-renamed
+            # "support_billing" clone.
+            pattern = re.compile(
+                r"\b(?:" + "|".join(
+                    re.escape(n) for n in sorted(name_map, key=len, reverse=True)
+                ) + r")\b")
+
+            def _substitute(text: Optional[str]) -> Optional[str]:
+                if not text or not isinstance(text, str):
+                    return text
+                return pattern.sub(lambda m: name_map[m.group(0)], text)
+
+            cloned = []
+            for old_name in tree_order:
+                source = by_name[old_name]
+                # Parents outside the cloned tree are dropped: the clone must form
+                # its own tree in the target project, not attach to the source one.
+                new_parents = [name_map[p] for p in source.get_parent_agents()
+                               if p in name_map]
+                config_data = {
+                    "name": name_map[old_name],
+                    "type": source.type,
+                    "model_name": source.model_name,
+                    "description": source.description,
+                    "instruction": _substitute(source.instruction),
+                    "mcp_servers_config": _substitute(source.mcp_servers_config),
+                    "parent_agents": new_parents,
+                    "allowed_for_roles": source.allowed_for_roles,
+                    "tool_config": _substitute(source.tool_config),
+                    "max_iterations": source.max_iterations,
+                    "planner_config": source.planner_config,
+                    "generate_content_config": source.generate_content_config,
+                    "input_schema": source.input_schema,
+                    "output_schema": source.output_schema,
+                    "include_contents": source.include_contents,
+                    "guardrail_config": _substitute(source.guardrail_config),
+                    "disabled": source.disabled,
+                    # A hardcoded agent's behaviour lives in its code folder, which
+                    # is not cloned — the copy is fully database-driven.
+                    "hardcoded": False,
+                    "expose_as_model": source.expose_as_model,
+                    "debug_mode": source.debug_mode,
+                    "project_id": target_project_id,
+                }
+                if not self._create_agent_config(config_data, changed_by=changed_by):
+                    return {"error": f"Failed to create clone of '{old_name}'",
+                            "status_code": 500,
+                            "cloned": cloned}
+                cloned.append({"old": old_name, "new": name_map[old_name]})
+
+            # Folder for the cloned root only — the ADK entry point, matching what
+            # _import_template does for a fresh project.
+            self._copy_template_agent(name_map[root.name])
+
+            memory_blocks_copied = 0
+            if include_memory_blocks:
+                from shared.utils.memory_blocks_service import MemoryBlocksService
+                from shared.utils.models import MemoryBlock
+                mem_service = MemoryBlocksService(self.db_client)
+                existing_labels = {b.label for b in session.query(MemoryBlock).filter(
+                    MemoryBlock.project_id == target_project_id).all()}
+                for block in session.query(MemoryBlock).filter(
+                        MemoryBlock.project_id == root.project_id).all():
+                    if block.label in existing_labels:
+                        continue
+                    result = mem_service.create_block(
+                        project_id=target_project_id, label=block.label,
+                        value=block.value, description=block.description)
+                    if result.get("status") == "success":
+                        memory_blocks_copied += 1
+
+            file_search_assigned = 0
+            if include_file_search:
+                from shared.utils.models import AgentFileSearchStore
+                assignments = session.query(AgentFileSearchStore).filter(
+                    AgentFileSearchStore.agent_name.in_(list(name_map.keys()))).all()
+                for assignment in assignments:
+                    # The remote store and its documents are shared, not duplicated —
+                    # duplicating would mean re-uploading everything to a new store.
+                    session.add(AgentFileSearchStore(
+                        agent_name=name_map[assignment.agent_name],
+                        store_id=assignment.store_id,
+                        is_primary=assignment.is_primary))
+                    file_search_assigned += 1
+                session.commit()
+
+            try:
+                from shared.utils import audit_service
+                audit_service.log(
+                    actor=changed_by or "unknown",
+                    action=audit_service.ACTION_AGENT_CLONE,
+                    resource_type="agent",
+                    resource_id=root_name,
+                    details={"target_project_id": target_project_id,
+                             "new_root": name_map[root.name],
+                             "agents_cloned": len(cloned)})
+            except Exception as e:
+                logger.warning(f"Audit entry for clone failed: {e}")
+
+            # Same hot reload as a template import — this is what makes the
+            # clones immediately loadable.
+            try:
+                from shared.utils.utils import get_adk_config
+                import httpx
+                adk_config = get_adk_config()
+                adk_url = f"http://{adk_config['adk_host']}:{adk_config['adk_port']}/api/reload-all-agents"
+                with httpx.Client(timeout=30.0) as client:
+                    client.post(adk_url)
+            except Exception:
+                pass
+
+            return {"success": True,
+                    "cloned": cloned,
+                    "new_root": name_map[root.name],
+                    "memory_blocks_copied": memory_blocks_copied,
+                    "file_search_assigned": file_search_assigned}
+        except Exception as e:
+            session.rollback()
+            logger.error(f"Agent clone failed: {e}")
+            return {"error": str(e), "status_code": 500}
+        finally:
+            session.close()
+
     def _import_template(self, template_id: Optional[str] = None, project_name: Optional[str] = None,
                          changed_by: str = None, template_dict: Optional[Dict[str, Any]] = None,
                          substitutions: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
@@ -3974,6 +4170,33 @@ class DashboardServer:
                 media_type=media_type,
                 headers={"Content-Disposition": f'attachment; filename="{filename}"'},
             )
+
+        @self.app.post("/dashboard/api/agents/{agent_name}/clone", tags=["Dashboard - Agents"])
+        async def clone_agent_tree(
+            agent_name: str,
+            request: Request,
+            username: str = Depends(self._get_auth_user_dependency),
+        ):
+            """Deep-copy a root agent and its sub-agent tree into another project."""
+            if not self._get_is_admin(request):
+                raise HTTPException(status_code=403, detail="Forbidden")
+            body = await request.json()
+            try:
+                target_project_id = int(body.get("target_project_id"))
+            except (TypeError, ValueError):
+                raise HTTPException(status_code=400, detail="target_project_id is required")
+            result = self._clone_agent_tree(
+                root_name=agent_name,
+                target_project_id=target_project_id,
+                suffix=body.get("suffix") or "",
+                include_memory_blocks=bool(body.get("include_memory_blocks")),
+                include_file_search=bool(body.get("include_file_search")),
+                changed_by=username,
+            )
+            if "error" in result:
+                raise HTTPException(status_code=result.get("status_code", 500),
+                                    detail=result["error"])
+            return result
 
         @self.app.post("/dashboard/api/agents/import", tags=["Dashboard - Agents"])
         async def import_agents(

--- a/static/js/agent-utils.js
+++ b/static/js/agent-utils.js
@@ -156,6 +156,79 @@ function hideCopyAgentModal() {
     }
 }
 
+// --- Clone agent tree to another project (#19) -------------------------
+
+let cloneAgentRootName = null;
+
+// Mirrors TemplateService.slugify_project_name so the pre-filled suffix matches
+// what a template import would have produced for the same project.
+function slugifyProjectName(name) {
+    let text = String(name || '').toLowerCase().trim();
+    text = text.replace(/[^\w\s-]/g, '');
+    text = text.replace(/[-\s]+/g, '_');
+    return text.replace(/^_+|_+$/g, '') || 'project';
+}
+
+function showCloneAgentModal(rootName) {
+    cloneAgentRootName = rootName;
+    const select = document.getElementById('cloneTargetProject');
+    select.innerHTML = (window.projects || []).map(
+        p => `<option value="${p.id}">${p.name}</option>`).join('');
+    document.getElementById('cloneAgentRootLabel').textContent = rootName;
+    updateCloneSuffix();
+    document.getElementById('cloneAgentModal').classList.remove('hidden');
+}
+
+function hideCloneAgentModal() {
+    document.getElementById('cloneAgentModal').classList.add('hidden');
+    cloneAgentRootName = null;
+}
+
+function updateCloneSuffix() {
+    const select = document.getElementById('cloneTargetProject');
+    const project = (window.projects || []).find(p => String(p.id) === select.value);
+    document.getElementById('cloneSuffix').value = '_' + slugifyProjectName(project ? project.name : '');
+    updateClonePreview();
+}
+
+function updateClonePreview() {
+    const suffix = document.getElementById('cloneSuffix').value;
+    document.getElementById('clonePreview').textContent =
+        cloneAgentRootName ? `${cloneAgentRootName}${suffix}` : '';
+}
+
+async function submitCloneAgent() {
+    const targetId = document.getElementById('cloneTargetProject').value;
+    const suffix = document.getElementById('cloneSuffix').value.trim();
+    if (!cloneAgentRootName || !targetId || !suffix) {
+        showNotification('Target project and suffix are required', 'error');
+        return;
+    }
+    try {
+        const resp = await fetch(`/dashboard/api/agents/${encodeURIComponent(cloneAgentRootName)}/clone`, {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                target_project_id: parseInt(targetId, 10),
+                suffix: suffix,
+                include_memory_blocks: document.getElementById('cloneMemoryBlocks').checked,
+                include_file_search: document.getElementById('cloneFileSearch').checked,
+            }),
+        });
+        const data = await resp.json();
+        if (!resp.ok) {
+            showNotification(data.detail || 'Clone failed', 'error');
+            return;
+        }
+        hideCloneAgentModal();
+        showNotification(`Cloned ${data.cloned.length} agent(s) — new root: ${data.new_root}`);
+        if (typeof refreshAgentsPage === 'function') refreshAgentsPage();
+    } catch (e) {
+        showNotification('Clone failed', 'error');
+    }
+}
+
 const CHAT_USER_STORAGE_KEY = 'agentChatSelectedUserId';
 let chatUsersCache = null;
 let chatUserFetchPromise = null;
@@ -1600,6 +1673,18 @@ function createAgentRow(config, depth, parentName, hasChildren, isHighlighted, r
             copyAgentById(config.id);
         }
     }));
+
+    if (getParentList(config).length === 0) {
+        actionsWrap.appendChild(createActionButton({
+            title: 'Clone to project',
+            icon: 'fas fa-clone',
+            className: 'text-teal-600 dark:text-teal-400 hover:text-teal-900 dark:hover:text-teal-300',
+            onClick: (event) => {
+                event.stopPropagation();
+                showCloneAgentModal(config.name);
+            }
+        }));
+    }
 
     actionsWrap.appendChild(createActionButton({
         title: 'Reload',

--- a/templates/dashboard/agents.html
+++ b/templates/dashboard/agents.html
@@ -207,6 +207,46 @@
             </div>
         </div>
 
+        <!-- Clone Agent Tree Modal -->
+        <div id="cloneAgentModal" class="hidden fixed inset-0 bg-black/50 z-50 flex items-center justify-center dashboard-modal">
+            <div class="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-md w-full mx-4 p-4">
+                <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-1">Clone to Project</h3>
+                <p class="text-xs text-gray-500 dark:text-gray-400 mb-4">
+                    Copies <span id="cloneAgentRootLabel" class="font-mono"></span> and its whole sub-agent tree.
+                    The source is not modified.
+                </p>
+                <div class="space-y-3">
+                    <div>
+                        <label class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">Target project</label>
+                        <select id="cloneTargetProject" onchange="updateCloneSuffix()"
+                                class="w-full border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded px-2 py-1.5 text-sm"></select>
+                    </div>
+                    <div>
+                        <label class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">Name suffix (applied to every cloned agent)</label>
+                        <input type="text" id="cloneSuffix" oninput="updateClonePreview()"
+                               class="w-full border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded px-2 py-1.5 text-sm font-mono">
+                        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                            New root: <span id="clonePreview" class="font-mono"></span>
+                        </p>
+                    </div>
+                    <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+                        <input type="checkbox" id="cloneMemoryBlocks" checked>
+                        Copy the source project's memory blocks (existing labels kept)
+                    </label>
+                    <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+                        <input type="checkbox" id="cloneFileSearch" checked>
+                        Assign the same file-search stores to the clones
+                    </label>
+                </div>
+                <div class="flex justify-end gap-2 pt-4">
+                    <button type="button" onclick="hideCloneAgentModal()"
+                            class="px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 dark:text-gray-200 rounded-lg">Cancel</button>
+                    <button type="button" onclick="submitCloneAgent()"
+                            class="px-3 py-2 text-sm bg-teal-600 hover:bg-teal-700 text-white rounded-lg">Clone</button>
+                </div>
+            </div>
+        </div>
+
         <!-- Agent Chat Panel and Chat User Selection Modal -->
         {% include 'dashboard/modals/chat_modals.html' %}
 


### PR DESCRIPTION
Implements #19. One commit.

## What the issue asked for, verified first

All of the issue's claims held against `main`: export/import exist, `agent_config_versions` covers rollback, and the "folders created as for a normal agent" criterion maps to `_copy_template_agent`, which template import already calls. One thing the issue does not spell out shaped the design: **agent names are globally unique across projects**, so every cloned agent needs a new name — not just collision cases. Naming is therefore the first-class decision, not an edge case.

## Design (user-confirmed)

- **Editable suffix applied to every agent in the tree**, pre-filled with `_<target_project_slug>` — the same convention template import uses — bumped `_2`/`_3` on collision.
- **Row action on root agents only** (agents with no parents), opening a modal with target project, live name preview, and two checkboxes.
- **Memory blocks copied** (existing target labels win); **file-search assignments duplicated pointing at the same store** — the remote Gemini store is shared, since duplicating it would mean re-uploading every document.

## How it works

`_clone_agent_tree` on `DashboardServer`, beside `_import_template` whose helpers it reuses. **Insert-only**: no source row is ever updated, which is what makes the "without corrupting the source" criterion hold by construction rather than by care.

- Sub-agents collected by BFS over `parent_agents` within the source project. A sub-agent with two in-tree parents is cloned once with both parents mapped; a parent **outside** the tree is dropped, so the clone forms its own hierarchy instead of attaching to the source one.
- In-tree name references inside `instruction` / `tool_config` / `guardrail_config` / `mcp_servers_config` follow the rename via a **single-pass word-boundary regex, longest name first**. The sequential `.replace` that `_import_template` uses would corrupt nested names — renaming `support` would also hit the middle of an already-renamed `support_billing` — and a test pins exactly that case.
- Clones go through `_create_agent_config`, so they get version snapshots like any other agent; the cloned root gets its `agents/` folder; `hardcoded` is forced off (a hardcoded agent's behaviour lives in its code folder, which is not cloned).
- Audit entry `agent.clone` (new constant), then the same `reload-all-agents` call a template import makes — that is what satisfies "immediately loadable".

Endpoint: `POST /dashboard/api/agents/{name}/clone`, admin-only.

## Verification

666 tests pass, 15 new — tree walk with multi-parent and out-of-tree cases, nested-name rewrite, collision bump, source untouched before/after, memory-block label precedence, shared store id, audit row, and the 400/404 rejections.

Live against a running server: cloning `chess_mate_root` copied 4 agents and 7 memory blocks into a fresh project, parents rewritten, source intact, folder created, audit row written. The modal drove the same flow end to end from a browser — project select re-derives the suffix, typing updates the preview, submit landed 4 rows.

**Not verified:** the row button's placement in the agents table. The table depends on a CDN asset unreachable from the sandbox, so it renders no rows there at all (existing Edit/Copy buttons included). The button shares the exact cell and gating (`getParentList(config).length === 0`) as the verified buttons around it — worth one glance on a real deployment.

No migration — the feature only inserts into existing tables.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ToCUNy2SqwvfTq4a6xfSk1)_