### PR TITLE
fix(templates): stop name substitution corrupting nested agent names

### DIFF
--- a/shared/test/test_name_substitution.py
+++ b/shared/test/test_name_substitution.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+Tests for agent-name substitution during template import and sync (#74).
+
+Four copies of a `sub_names` helper rewrote names with a loop of `str.replace`.
+That has two defects: it rewrites text a previous replacement produced, and it
+has no notion of a whole word. With agents `support` and `support_billing`,
+mapping `support` first also rewrote the middle of `support_billing`. Whether
+it happened depended on dict ordering, so it was intermittent.
+
+All four now share `make_name_substituter`, which does one pass with word
+boundaries, longest name first.
+"""
+
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from shared.utils.dashboard.dashboard_server import make_name_substituter
+
+
+class TestMakeNameSubstituter(unittest.TestCase):
+
+    def test_nested_name_is_not_corrupted(self):
+        # The original bug, stated directly.
+        sub = make_name_substituter({"support": "support_acme",
+                                     "support_billing": "support_billing_acme"})
+        self.assertEqual(sub("support and support_billing"),
+                         "support_acme and support_billing_acme")
+
+    def test_longest_match_wins_regardless_of_map_order(self):
+        # Sequential replace was order-dependent; this must not be.
+        forward = make_name_substituter({"a_b": "X", "a_b_c": "Y"})
+        reverse = make_name_substituter({"a_b_c": "Y", "a_b": "X"})
+        self.assertEqual(forward("a_b_c"), "Y")
+        self.assertEqual(reverse("a_b_c"), "Y")
+
+    def test_a_replacement_is_not_itself_rewritten(self):
+        # Looping replace would map alpha -> beta, then beta -> gamma.
+        sub = make_name_substituter({"alpha": "beta", "beta": "gamma"})
+        self.assertEqual(sub("alpha"), "beta")
+
+    def test_word_boundaries_are_respected(self):
+        sub = make_name_substituter({"bot": "robot"})
+        self.assertEqual(sub("bot"), "robot")
+        self.assertEqual(sub("sandbot"), "sandbot")
+        self.assertEqual(sub("bots"), "bots")
+
+    def test_names_with_regex_metacharacters_are_literal(self):
+        sub = make_name_substituter({"a.b": "X"})
+        self.assertEqual(sub("a.b"), "X")
+        self.assertEqual(sub("axb"), "axb")
+
+    def test_recurses_through_lists_and_dicts(self):
+        sub = make_name_substituter({"old": "new"})
+        self.assertEqual(sub(["old", {"k": "old"}]), ["new", {"k": "new"}])
+
+    def test_non_string_values_pass_through(self):
+        sub = make_name_substituter({"old": "new"})
+        self.assertEqual(sub({"n": 5, "b": True, "z": None}), {"n": 5, "b": True, "z": None})
+
+    def test_empty_map_is_an_identity(self):
+        # An empty alternation would compile to a pattern matching everywhere.
+        sub = make_name_substituter({})
+        self.assertEqual(sub("support and support_billing"), "support and support_billing")
+
+
+class TestTemplateImportNestedNames(unittest.TestCase):
+    """The bug reaching a real caller: importing a template whose names nest."""
+
+    @patch("shared.utils.database_client.get_database_client")
+    def test_import_does_not_corrupt_nested_agent_names(self, mock_get_db):
+        from fastapi import FastAPI
+        from shared.utils.dashboard.dashboard_server import DashboardServer
+
+        mock_get_db.return_value = MagicMock()
+        project_root = Path(os.path.dirname(os.path.dirname(
+            os.path.dirname(os.path.abspath(__file__)))))
+        server = DashboardServer(app=FastAPI(), project_root=project_root)
+        server._create_project = MagicMock(return_value={"id": 42})
+        server._copy_template_agent = MagicMock()
+
+        created = []
+        server._create_agent_config = MagicMock(
+            side_effect=lambda cfg, changed_by=None: created.append(cfg) or True)
+
+        template = {
+            "template_meta": {"id": "t", "agent_prefix": "tpl_", "root_agent": "tpl_support"},
+            "agents": [
+                {"name": "tpl_support", "type": "llm", "parent_agents": [],
+                 "instruction": "Delegate billing to tpl_support_billing."},
+                {"name": "tpl_support_billing", "type": "llm",
+                 "parent_agents": ["tpl_support"], "instruction": "Handle billing."},
+            ],
+        }
+        result = server._import_template(template_dict=template, project_name="Acme")
+        self.assertNotIn("error", result)
+
+        by_old = {c["name"]: c for c in created}
+        self.assertEqual(len(created), 2)
+
+        root = next(c for c in created if c["parent_agents"] == [])
+        child = next(c for c in created if c["parent_agents"] != [])
+
+        # The child's own name must not have the root's replacement spliced into it.
+        self.assertTrue(child["name"].endswith("_billing"), child["name"])
+        # The root's instruction must point at the child's real new name.
+        self.assertIn(child["name"], root["instruction"])
+        # And the child must be parented to the root's real new name.
+        self.assertEqual(child["parent_agents"], [root["name"]])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/shared/utils/dashboard/dashboard_server.py
+++ b/shared/utils/dashboard/dashboard_server.py
@@ -7,6 +7,7 @@ import json
 import logging
 import math
 import os
+import re
 import sys
 import shutil
 from datetime import datetime
@@ -45,6 +46,39 @@ def sanitize_agent_text(text: Optional[str]) -> Optional[str]:
     text = text.replace('‘', "'").replace('’', "'")
     text = text.replace('“', '"').replace('”', '"')
     return text
+
+
+def make_name_substituter(name_map: Dict[str, str]):
+    """Build a substituter that rewrites agent names in strings, lists and dicts.
+
+    Renaming has to be a single pass with word boundaries, not a loop of
+    ``str.replace``. Sequential replacement rewrites text that a previous
+    replacement produced, and it has no notion of a whole word — so with agents
+    ``support`` and ``support_billing``, mapping ``support`` first also rewrites
+    the middle of ``support_billing`` and yields ``support_acme_billing``.
+    Whether that happens depends on dict order, which makes it intermittent.
+
+    Longest names are tried first so ``support_billing`` wins over ``support``
+    where both could match at the same position.
+    """
+    names = [n for n in name_map if n]
+    if not names:
+        return lambda obj: obj
+
+    pattern = re.compile(
+        r"\b(?:" + "|".join(re.escape(n) for n in sorted(names, key=len, reverse=True)) + r")\b"
+    )
+
+    def substitute(obj):
+        if isinstance(obj, str):
+            return pattern.sub(lambda m: name_map[m.group(0)], obj)
+        if isinstance(obj, list):
+            return [substitute(x) for x in obj]
+        if isinstance(obj, dict):
+            return {k: substitute(v) for k, v in obj.items()}
+        return obj
+
+    return substitute
 
 
 class DashboardServer:
@@ -1864,8 +1898,6 @@ class DashboardServer:
         are globally unique, so every clone gets `name + suffix` (bumped with _2/_3
         on collision), and in-tree name references in text fields follow the rename.
         """
-        import re
-
         suffix = (suffix or "").strip()
         if not suffix:
             return {"error": "suffix is required", "status_code": 400}
@@ -1923,20 +1955,8 @@ class DashboardServer:
                     candidate = f"{old_name}{suffix}_{bump}"
                 name_map[old_name] = candidate
 
-            # In-tree references inside text fields follow the rename. A single-pass
-            # regex with word boundaries, longest name first: sequential .replace (as
-            # sub_names in _import_template does) corrupts nested names — renaming
-            # "support" would also hit the middle of an already-renamed
-            # "support_billing" clone.
-            pattern = re.compile(
-                r"\b(?:" + "|".join(
-                    re.escape(n) for n in sorted(name_map, key=len, reverse=True)
-                ) + r")\b")
-
-            def _substitute(text: Optional[str]) -> Optional[str]:
-                if not text or not isinstance(text, str):
-                    return text
-                return pattern.sub(lambda m: name_map[m.group(0)], text)
+            # In-tree references inside text fields follow the rename.
+            _substitute = make_name_substituter(name_map)
 
             cloned = []
             for old_name in tree_order:
@@ -2124,16 +2144,7 @@ class DashboardServer:
         root_agent_name = name_map.get(root_agent_raw, root_agent_raw)
 
         # Substitute in agent names and parent_agents
-        def sub_names(obj):
-            if isinstance(obj, str):
-                for old, new in name_map.items():
-                    obj = obj.replace(old, new)
-                return obj
-            if isinstance(obj, list):
-                return [sub_names(x) for x in obj]
-            if isinstance(obj, dict):
-                return {k: sub_names(v) for k, v in obj.items()}
-            return obj
+        sub_names = make_name_substituter(name_map)
         
         # Create agents in order: root first (no parents), then children
         agents_created = 0
@@ -2325,11 +2336,7 @@ class DashboardServer:
             agents_to_add = []
             agents_to_update = []
             
-            def sub_names(text):
-                if isinstance(text, str):
-                    for old, new in name_map.items():
-                        text = text.replace(old, new)
-                return text
+            sub_names = make_name_substituter(name_map)
 
             for tpl_agent in template_agents:
                 tpl_name = tpl_agent.get("name", "")
@@ -2400,11 +2407,7 @@ class DashboardServer:
             ).all()
             db_block_labels = {b.label for b in db_blocks}
             
-            def sub_names(text):
-                if isinstance(text, str):
-                    for old, new in name_map.items():
-                        text = text.replace(old, new)
-                return text
+            sub_names = make_name_substituter(name_map)
             
             blocks_to_add = []
             blocks_to_update = []
@@ -2474,16 +2477,7 @@ class DashboardServer:
                     new_name = old_name.replace(tpl_prefix, replace_with, 1) if tpl_prefix in old_name else f"{slug}_{old_name}"
                     name_map[old_name] = new_name
             
-            def sub_names(obj):
-                if isinstance(obj, str):
-                    for old, new in name_map.items():
-                        obj = obj.replace(old, new)
-                    return obj
-                if isinstance(obj, list):
-                    return [sub_names(x) for x in obj]
-                if isinstance(obj, dict):
-                    return {k: sub_names(v) for k, v in obj.items()}
-                return obj
+            sub_names = make_name_substituter(name_map)
             
             # Get existing DB agents
             db_agents = session.query(self.AgentConfig).filter(


### PR DESCRIPTION
Closes #74. One commit.

## The problem

Four copies of a `sub_names` helper rewrote agent names with a loop of `str.replace` — once in `_import_template`, twice in `_get_template_sync_status`, once in `_sync_template`.

Sequential replacement has two defects:

1. **It rewrites what a previous replacement produced.** A map of `{alpha: beta, beta: gamma}` turns `"alpha"` into `"gamma"`.
2. **It has no notion of a whole word.** When one agent's name is a prefix of another's, the shorter mapping fires inside the longer name — with `support` and `support_billing`, mapping `support` first also rewrites the middle of `support_billing`.

Which one bites depends on `dict` iteration order. That is why it survived: intermittent, and the corruption is silent — it lands in instructions and tool configs at import time and nothing reports it.

## The fix

All four share `make_name_substituter`: one pass over the text with `\b` boundaries, alternation ordered longest-name-first so `support_billing` wins over `support` at the same position, and names `re.escape`d so a dot in a name cannot match arbitrary characters.

An empty map short-circuits to identity — an empty alternation would otherwise compile to a pattern that matches at every position.

`_clone_agent_tree` had already solved this inline for #19; it now calls the shared helper too, so there is **one** implementation rather than two correct ones and four wrong ones. Its local `import re` became unused and is removed.

## Verification

703 tests pass, 9 new. The suite was confirmed to **fail against the previous implementation** — four of the nine break when the helper is reverted to sequential replace, including the nested-name case and the order-independence case.

Live check: importing a template containing `tpl_support`, `tpl_support_billing` and `tpl_support_tech` into a project named "Acme Corp" produces

```
acme_corp_support           parents=[]
acme_corp_support_billing   parents=['acme_corp_support']
acme_corp_support_tech      parents=['acme_corp_support']
```

with the root's instruction correctly rewritten to point at the renamed children.

No migration; this is a pure text-rewriting change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ToCUNy2SqwvfTq4a6xfSk1)_