### PR TITLE
feat(triggers): pass the webhook payload into the trigger prompt

### DIFF
--- a/documents/TRIGGERS.md
+++ b/documents/TRIGGERS.md
@@ -43,6 +43,47 @@ curl -X POST https://your-mate.example.com/triggers/{trigger_id}/fire \
   -H "Authorization: Bearer <token>"
 ```
 
+### Using the request body in the prompt
+
+The JSON body of the firing request is available to the trigger's prompt through
+`{{ payload }}` placeholders, so a webhook can say *what happened* instead of only *that
+something happened*.
+
+| Placeholder | Renders |
+|---|---|
+| `{{ payload }}` | the whole body as JSON |
+| `{{ payload.key }}` | one top-level field |
+| `{{ payload.issue.fields.summary }}` | a nested field, by dotted path |
+| `{{ payload.commits.0.id }}` | a list element, by index |
+
+```bash
+curl -X POST https://your-mate.example.com/triggers/7/fire \
+  -H "X-MATE-Trigger-Key: <fire_key>" \
+  -H "Content-Type: application/json" \
+  -d '{"key": "MT-32", "action": "updated"}'
+```
+
+With the prompt `Issue {{ payload.key }} was {{ payload.action }} — summarise it`, the agent
+receives `Issue MT-32 was updated — summarise it`.
+
+Notes:
+
+- A prompt with no placeholder is sent unchanged, so existing triggers behave exactly as
+  before. A body that is missing or is not JSON is not an error — the trigger fires with no
+  payload and placeholders are left as-is.
+- An unresolved path renders empty rather than failing, so one missing field does not stop
+  the run.
+- Each substituted value is capped at 4,000 characters and truncated with a marker beyond
+  that, so an oversized POST cannot inflate the prompt or the token bill.
+- Substitution is single-pass: a body that itself contains `{{ payload.x }}` is inserted as
+  literal text, not re-expanded.
+- `POST /dashboard/api/triggers/{id}/test-fire` accepts the same JSON body, so you can
+  exercise a payload-using prompt from the dashboard before wiring up the real caller.
+
+> **Treat the body as untrusted input.** Whoever holds the fire key controls text that goes
+> straight into an agent prompt. Enable the `prompt_injection` guardrail on any agent whose
+> trigger interpolates a payload, and keep the trigger's output destination narrow.
+
 ### Fire key lifecycle
 
 - A **fire key** is generated when you create a webhook trigger. It is shown **once** in a dashboard banner — copy it immediately.

--- a/shared/test/test_trigger_payload.py
+++ b/shared/test/test_trigger_payload.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""
+Tests for webhook payloads reaching the trigger prompt (#75).
+
+`execute_trigger` took no payload and the fire endpoint never read the body, so
+an external system could fire a trigger but not tell it anything — the agent
+always saw the same fixed prompt. These tests pin the substitution, the size
+cap that keeps an attacker-influenced body from becoming an unbounded prompt,
+and that triggers written before payloads existed still render unchanged.
+"""
+
+import json
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from shared.utils.trigger_runner import (
+    MAX_PAYLOAD_CHARS, TriggerRunner, render_prompt,
+)
+
+
+class TestRenderPrompt(unittest.TestCase):
+
+    def test_whole_payload_placeholder(self):
+        out = render_prompt("Handle: {{ payload }}", {"a": 1})
+        self.assertEqual(out, 'Handle: {"a": 1}')
+
+    def test_field_placeholder(self):
+        out = render_prompt("Issue {{ payload.key }} changed", {"key": "MT-32"})
+        self.assertEqual(out, "Issue MT-32 changed")
+
+    def test_nested_path(self):
+        out = render_prompt("{{ payload.issue.fields.summary }}",
+                            {"issue": {"fields": {"summary": "Login broken"}}})
+        self.assertEqual(out, "Login broken")
+
+    def test_list_index_in_path(self):
+        out = render_prompt("{{ payload.commits.0.id }}",
+                            {"commits": [{"id": "abc123"}, {"id": "def456"}]})
+        self.assertEqual(out, "abc123")
+
+    def test_missing_path_renders_empty_rather_than_raising(self):
+        # A trigger firing with one field absent should still run.
+        self.assertEqual(render_prompt("[{{ payload.nope }}]", {"key": "v"}), "[]")
+
+    def test_whitespace_inside_braces_is_tolerated(self):
+        self.assertEqual(render_prompt("{{payload.k}}|{{  payload.k  }}", {"k": "x"}), "x|x")
+
+    def test_non_string_values_are_json_encoded(self):
+        self.assertEqual(render_prompt("{{ payload.n }}", {"n": 42}), "42")
+        self.assertEqual(render_prompt("{{ payload.o }}", {"o": {"k": 1}}), '{"k": 1}')
+
+    def test_prompt_without_placeholder_is_untouched(self):
+        prompt = "Summarise today's sales."
+        self.assertEqual(render_prompt(prompt, {"anything": 1}), prompt)
+
+    def test_no_payload_leaves_placeholders_alone(self):
+        # Cron firings pass nothing; the prompt must not be mangled.
+        prompt = "Report {{ payload.k }}"
+        self.assertEqual(render_prompt(prompt, None), prompt)
+
+    def test_oversized_value_is_truncated(self):
+        out = render_prompt("{{ payload.big }}", {"big": "x" * (MAX_PAYLOAD_CHARS + 5000)})
+        self.assertLess(len(out), MAX_PAYLOAD_CHARS + 200)
+        self.assertIn("truncated", out)
+
+    def test_oversized_whole_payload_is_truncated(self):
+        out = render_prompt("{{ payload }}", {"big": "x" * (MAX_PAYLOAD_CHARS + 5000)})
+        self.assertLess(len(out), MAX_PAYLOAD_CHARS + 200)
+
+    def test_payload_text_is_not_itself_treated_as_a_template(self):
+        # A body containing a placeholder must not trigger a second substitution.
+        out = render_prompt("{{ payload.k }}", {"k": "{{ payload.secret }}"})
+        self.assertEqual(out, "{{ payload.secret }}")
+
+
+class TestExecuteTriggerThreadsPayload(unittest.TestCase):
+
+    def setUp(self):
+        self.runner = TriggerRunner()
+        self.trigger = MagicMock(
+            id=1, trigger_type="webhook", agent_name="a1",
+            prompt="Issue {{ payload.key }} needs attention",
+        )
+        self.runner._route_output = MagicMock()
+
+    def test_payload_reaches_the_agent_prompt(self):
+        self.runner._invoke_agent = MagicMock(return_value="done")
+        self.runner._execute_trigger_sync(self.trigger, {"key": "MT-99"})
+        self.runner._invoke_agent.assert_called_once_with(
+            "a1", "Issue MT-99 needs attention")
+
+    def test_cron_firing_passes_no_payload(self):
+        self.runner._invoke_agent = MagicMock(return_value="done")
+        self.runner._execute_trigger_sync(self.trigger)
+        self.runner._invoke_agent.assert_called_once_with(
+            "a1", "Issue {{ payload.key }} needs attention")
+
+
+class TestFireEndpointReadsTheBody(unittest.TestCase):
+    """The endpoint used to discard the body entirely."""
+
+    def test_webhook_fire_passes_the_body_through(self):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from pathlib import Path
+        from shared.utils.dashboard.dashboard_server import DashboardServer
+
+        with patch("shared.utils.database_client.get_database_client",
+                   return_value=MagicMock()):
+            project_root = Path(os.path.dirname(os.path.dirname(
+                os.path.dirname(os.path.abspath(__file__)))))
+            app = FastAPI()
+            server = DashboardServer(app, project_root)
+
+        trigger_row = MagicMock(id=7, fire_key_hash=None)
+        session = MagicMock()
+        session.query.return_value.filter.return_value.first.return_value = trigger_row
+        server.db_client = MagicMock()
+        server.db_client.get_session.return_value = session
+
+        runner = MagicMock()
+        runner.execute_trigger.return_value = {"status": "ok", "agent_response": "x"}
+
+        with patch("shared.utils.trigger_runner.get_trigger_runner", return_value=runner), \
+             patch("server.auth.require_dashboard_auth", return_value=True):
+            client = TestClient(app)
+            body = {"key": "MT-1", "action": "updated"}
+            resp = client.post("/triggers/7/fire", json=body)
+
+        self.assertEqual(resp.status_code, 200)
+        runner.execute_trigger.assert_called_once_with(7, body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/shared/utils/dashboard/dashboard_server.py
+++ b/shared/utils/dashboard/dashboard_server.py
@@ -6527,9 +6527,18 @@ class DashboardServer:
             request: Request,
             username: str = Depends(self._get_auth_user_dependency),
         ):
-            """Immediately execute a trigger and return the result."""
+            """Immediately execute a trigger and return the result.
+
+            Accepts an optional JSON body so a prompt using {{ payload }} can be
+            tested with a sample body — otherwise the only way to exercise one
+            would be to fire the real webhook.
+            """
             from shared.utils.trigger_runner import get_trigger_runner
-            result = get_trigger_runner().execute_trigger(trigger_id)
+            try:
+                payload = await request.json()
+            except Exception:
+                payload = None
+            result = get_trigger_runner().execute_trigger(trigger_id, payload)
             if result.get("status") == "error":
                 raise HTTPException(status_code=500, detail=result.get("message", "Trigger execution failed"))
             return {"result": result}
@@ -6725,7 +6734,16 @@ class DashboardServer:
                         detail="Authentication required: provide X-MATE-Trigger-Key header or dashboard credentials",
                     )
 
-            result = get_trigger_runner().execute_trigger(trigger_id)
+            # The firing system's body reaches the prompt through {{ payload }}.
+            # A body that is absent or not JSON is not an error: plenty of
+            # webhooks fire with nothing, and those triggers ran before payloads
+            # existed and must keep running.
+            try:
+                payload = await request.json()
+            except Exception:
+                payload = None
+
+            result = get_trigger_runner().execute_trigger(trigger_id, payload)
             if result.get("status") == "error":
                 raise HTTPException(status_code=500, detail=result.get("message", "Trigger execution failed"))
             return result

--- a/shared/utils/trigger_runner.py
+++ b/shared/utils/trigger_runner.py
@@ -35,6 +35,58 @@ def get_trigger_runner() -> "TriggerRunner":
     return _runner_instance
 
 
+# A webhook body is attacker-influenced text heading straight into a prompt, so
+# it is bounded before it gets there. The cap is per substituted value: a runaway
+# POST costs a truncated placeholder, not an unbounded token bill.
+MAX_PAYLOAD_CHARS = 4000
+
+_PAYLOAD_PLACEHOLDER = re.compile(r"\{\{\s*payload(?:\.([A-Za-z0-9_.\-]+))?\s*\}\}")
+
+
+def _lookup_payload_path(payload: Any, path: str) -> Any:
+    """Walk a dotted path through the payload. Missing keys yield None."""
+    current = payload
+    for part in path.split("."):
+        if isinstance(current, dict) and part in current:
+            current = current[part]
+        elif isinstance(current, list) and part.isdigit() and int(part) < len(current):
+            current = current[int(part)]
+        else:
+            return None
+    return current
+
+
+def _stringify(value: Any) -> str:
+    """Render a payload value for inclusion in a prompt, bounded in length."""
+    if value is None:
+        return ""
+    text = value if isinstance(value, str) else json.dumps(value, ensure_ascii=False, default=str)
+    if len(text) > MAX_PAYLOAD_CHARS:
+        text = text[:MAX_PAYLOAD_CHARS] + f"... [truncated at {MAX_PAYLOAD_CHARS} chars]"
+    return text
+
+
+def render_prompt(prompt: str, payload: Any = None) -> str:
+    """Substitute {{ payload }} and {{ payload.a.b }} placeholders in a prompt.
+
+    A prompt with no placeholder is returned untouched, so triggers written
+    before payloads existed behave exactly as they did. An unresolved path
+    renders empty rather than raising: a trigger that fires with a field
+    missing should still run, and the agent can see the field is absent.
+    """
+    if not prompt or payload is None or "{{" not in prompt:
+        return prompt
+
+    def replace(match: "re.Match") -> str:
+        path = match.group(1)
+        value = payload if path is None else _lookup_payload_path(payload, path)
+        if path is not None and value is None:
+            logger.debug("Trigger payload has no path %r; rendering empty", path)
+        return _stringify(value)
+
+    return _PAYLOAD_PLACEHOLDER.sub(replace, prompt)
+
+
 def generate_webhook_path(name: str) -> str:
     """Generate a unique-enough webhook path slug from a trigger name."""
     slug = re.sub(r'[^a-z0-9-]', '-', name.lower().strip())[:40].strip('-') or 'trigger'
@@ -268,10 +320,13 @@ class TriggerRunner:
         except Exception as exc:
             logger.error("_run_trigger_by_id outer %s error: %s", trigger_id, exc)
 
-    def execute_trigger(self, trigger_id: int) -> Dict[str, Any]:
+    def execute_trigger(self, trigger_id: int, payload: Any = None) -> Dict[str, Any]:
         """
         Execute one trigger immediately (webhook fire or dashboard test-fire).
         Persists last_fired_at and last_result. Returns result dict.
+
+        ``payload`` is the decoded body of the firing request, available to the
+        trigger's prompt through {{ payload }} placeholders.
         """
         from shared.utils.database_client import get_database_client
         from shared.utils.models import AgentTrigger
@@ -285,7 +340,7 @@ class TriggerRunner:
             ).first()
             if not trigger:
                 return {"status": "error", "message": "Trigger not found"}
-            result = self._execute_trigger_sync(trigger)
+            result = self._execute_trigger_sync(trigger, payload)
             trigger.last_fired_at = datetime.now(timezone.utc)
             trigger.set_last_result(result)
             session.commit()
@@ -297,17 +352,20 @@ class TriggerRunner:
         finally:
             session.close()
 
-    def _execute_trigger_sync(self, trigger: Any) -> Dict[str, Any]:
+    def _execute_trigger_sync(self, trigger: Any, payload: Any = None) -> Dict[str, Any]:
         """
         Core execution: invoke ADK agent then route output.
         Returns result dict with status, optional agent_response.
+
+        Cron firings pass no payload; the prompt then renders unchanged.
         """
         if trigger.trigger_type in ("file_watch", "event_bus"):
             logger.info("Trigger %s type='%s' — not yet implemented", trigger.id, trigger.trigger_type)
             return {"status": "skipped", "message": f"trigger_type '{trigger.trigger_type}' not yet implemented"}
 
         try:
-            agent_response = self._invoke_agent(trigger.agent_name, trigger.prompt)
+            prompt = render_prompt(trigger.prompt, payload)
+            agent_response = self._invoke_agent(trigger.agent_name, prompt)
         except Exception as exc:
             return {"status": "error", "message": f"Agent invocation failed: {exc}"}
 


### PR DESCRIPTION
Closes #75. One commit.

## The problem

`execute_trigger` took no payload and the fire endpoint never read the request body. An external system could fire a trigger but not tell it anything — the agent always saw the fixed prompt stored at creation time.

That reduced webhook triggers to "run this text on demand", and left them unable to express "this issue changed" or "this build failed", which is most of what webhooks are for.

## The fix

Prompts interpolate the firing body:

| Placeholder | Renders |
|---|---|
| `{{ payload }}` | the whole body as JSON |
| `{{ payload.key }}` | one top-level field |
| `{{ payload.issue.fields.summary }}` | a nested field |
| `{{ payload.commits.0.id }}` | a list element by index |

**Rendering is forgiving in both directions**, deliberately:

- A prompt with no placeholder is returned untouched — existing triggers are bit-for-bit unaffected.
- A body that is absent or not JSON fires the trigger with no payload rather than erroring. Plenty of webhooks post nothing, and those triggers worked before.
- An unresolved path renders empty rather than raising. One missing field should not stop a run the agent could still do something useful with.

**The body is bounded on the way in.** It is attacker-influenced text heading into a prompt, so each substituted value is capped at 4,000 characters and truncated with a marker. Substitution is a single pass, so a body that itself contains `{{ payload.x }}` is inserted as literal text rather than re-expanded into a second lookup.

**`test-fire` accepts the same body.** Without it there is no way to exercise a payload-using prompt short of firing the real webhook — which would make the dashboard's test button useless for exactly the triggers most worth testing. This goes slightly beyond the issue's stated scope; flagging it rather than burying it.

## Verification

718 tests pass, 15 new — the placeholder forms, nested paths and list indices, missing paths, whitespace tolerance, both truncation paths, the no-payload and no-placeholder passthroughs, the single-pass property, and that the fire endpoint actually forwards the body it used to discard.

Live against a real trigger row in this instance:

```
stored prompt: issue={{ payload.key }} action={{ payload.action }} nested={{ payload.issue.fields.summary }}

WITH body    -> issue=MT-32 action=updated nested=Login broken
WITHOUT body -> (unchanged, placeholders intact)
PARTIAL body -> issue=K action= nested=
```

No migration — this changes how an existing column is rendered, not the schema.

## Security note

Whoever holds the fire key now controls text that goes straight into an agent prompt. `documents/TRIGGERS.md` says so plainly and recommends enabling the `prompt_injection` guardrail on any agent whose trigger interpolates a payload, plus keeping the output destination narrow.

HMAC signature verification of inbound webhooks is still not implemented — worth its own issue, and noted as out of scope in #75.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ToCUNy2SqwvfTq4a6xfSk1)_