### PR TITLE
fix(triggers): refuse trigger types that can never fire

### DIFF
--- a/shared/test/test_unimplemented_trigger_types.py
+++ b/shared/test/test_unimplemented_trigger_types.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""
+Tests that unfireable trigger types cannot be created (#76).
+
+`file_watch` and `event_bus` are accepted by the model and offered by the
+dashboard, but `_execute_trigger_sync` skips them with "not yet implemented".
+A user could therefore save a trigger that looks like automation and never runs.
+
+Creating one is now refused. Rows that already exist keep loading, listing and
+being editable — in particular they can still be disabled, which is the one
+thing an operator stuck with a dead trigger actually wants to do.
+"""
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from shared.utils.models import AgentTrigger, Base, Project
+from shared.utils.trigger_runner import UNIMPLEMENTED_TRIGGER_TYPES, TriggerRunner
+
+
+class TestUnimplementedTriggerTypes(unittest.TestCase):
+
+    def setUp(self):
+        self.engine = create_engine(
+            "sqlite:///:memory:",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(self.engine)
+        self.Session = sessionmaker(bind=self.engine)
+
+        self.db_client = MagicMock()
+        self.db_client.get_session.side_effect = lambda: self.Session()
+        self.patcher = patch("shared.utils.database_client.get_database_client",
+                             return_value=self.db_client)
+        self.patcher.start()
+
+        session = self.Session()
+        session.add(Project(id=1, name="P"))
+        session.commit()
+        session.close()
+
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from shared.utils.dashboard.dashboard_server import DashboardServer
+
+        project_root = Path(os.path.dirname(os.path.dirname(
+            os.path.dirname(os.path.abspath(__file__)))))
+        app = FastAPI()
+        self.server = DashboardServer(app, project_root)
+        self.server.db_client = self.db_client
+        app.dependency_overrides[self.server._get_auth_user_dependency] = lambda: "admin"
+        self.client = TestClient(app)
+
+    def tearDown(self):
+        self.patcher.stop()
+        self.engine.dispose()
+
+    def _body(self, trigger_type):
+        return {"name": "t", "trigger_type": trigger_type, "agent_name": "a1",
+                "project_id": 1, "prompt": "go", "cron_expression": "0 * * * *"}
+
+    def _seed_legacy(self, trigger_type="file_watch"):
+        session = self.Session()
+        row = AgentTrigger(name="legacy", trigger_type=trigger_type, agent_name="a1",
+                           project_id=1, prompt="go", is_enabled=True)
+        session.add(row)
+        session.commit()
+        row_id = row.id
+        session.close()
+        return row_id
+
+    def test_creating_an_unfireable_type_is_refused(self):
+        for trigger_type in UNIMPLEMENTED_TRIGGER_TYPES:
+            with self.subTest(trigger_type=trigger_type):
+                resp = self.client.post("/dashboard/api/triggers", json=self._body(trigger_type))
+                self.assertEqual(resp.status_code, 400)
+                self.assertIn("never fire", resp.json()["detail"])
+
+    def test_nothing_is_stored_when_refused(self):
+        self.client.post("/dashboard/api/triggers", json=self._body("file_watch"))
+        session = self.Session()
+        self.assertEqual(session.query(AgentTrigger).count(), 0)
+        session.close()
+
+    def test_working_types_are_still_accepted(self):
+        for trigger_type in ("cron", "webhook"):
+            with self.subTest(trigger_type=trigger_type):
+                resp = self.client.post("/dashboard/api/triggers", json=self._body(trigger_type))
+                self.assertEqual(resp.status_code, 200)
+
+    def test_converting_a_working_trigger_into_one_is_refused(self):
+        resp = self.client.post("/dashboard/api/triggers", json=self._body("cron"))
+        trigger_id = resp.json()["trigger"]["id"]
+        resp = self.client.put(f"/dashboard/api/triggers/{trigger_id}",
+                               json={"trigger_type": "event_bus"})
+        self.assertEqual(resp.status_code, 400)
+
+        session = self.Session()
+        self.assertEqual(session.get(AgentTrigger, trigger_id).trigger_type, "cron")
+        session.close()
+
+    def test_a_legacy_row_can_still_be_disabled(self):
+        # The one thing an operator stuck with a dead trigger needs to do.
+        trigger_id = self._seed_legacy()
+        resp = self.client.put(f"/dashboard/api/triggers/{trigger_id}",
+                               json={"trigger_type": "file_watch", "is_enabled": False})
+        self.assertEqual(resp.status_code, 200)
+
+        session = self.Session()
+        row = session.get(AgentTrigger, trigger_id)
+        self.assertFalse(row.is_enabled)
+        self.assertEqual(row.trigger_type, "file_watch")
+        session.close()
+
+    def test_a_legacy_row_still_lists(self):
+        self._seed_legacy()
+        resp = self.client.get("/dashboard/api/triggers")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual([t["trigger_type"] for t in resp.json()["triggers"]], ["file_watch"])
+
+    def test_firing_a_legacy_row_still_reports_skipped(self):
+        runner = TriggerRunner()
+        runner._invoke_agent = MagicMock()
+        trigger = MagicMock(id=1, trigger_type="file_watch")
+        result = runner._execute_trigger_sync(trigger)
+        self.assertEqual(result["status"], "skipped")
+        runner._invoke_agent.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/shared/utils/dashboard/dashboard_server.py
+++ b/shared/utils/dashboard/dashboard_server.py
@@ -6346,12 +6346,22 @@ class DashboardServer:
             """Create a new trigger. Returns trigger + fire_key (webhook triggers only, shown once)."""
             import re as _re
             import secrets as _secrets
-            from shared.utils.trigger_runner import get_trigger_runner, generate_webhook_path
+            from shared.utils.trigger_runner import (
+                UNIMPLEMENTED_TRIGGER_TYPES, get_trigger_runner, generate_webhook_path,
+            )
 
             if not self.db_client:
                 raise HTTPException(status_code=500, detail="Database unavailable")
             body = await request.json()
             trigger_type = body.get("trigger_type", "cron")
+            # Nothing fires these, so creating one only produces a row that looks
+            # like automation and never runs. Refuse rather than store it.
+            if trigger_type in UNIMPLEMENTED_TRIGGER_TYPES:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"trigger_type '{trigger_type}' is not implemented and would never fire. "
+                           "Use 'cron' or 'webhook'.",
+                )
             session = self.db_client.get_session()
             if not session:
                 raise HTTPException(status_code=500, detail="Database unavailable")
@@ -6410,7 +6420,7 @@ class DashboardServer:
             username: str = Depends(self._get_auth_user_dependency),
         ):
             """Update a trigger. Pass regenerate_fire_key=true to rotate the webhook key."""
-            from shared.utils.trigger_runner import get_trigger_runner
+            from shared.utils.trigger_runner import UNIMPLEMENTED_TRIGGER_TYPES, get_trigger_runner
 
             if not self.db_client:
                 raise HTTPException(status_code=500, detail="Database unavailable")
@@ -6424,6 +6434,18 @@ class DashboardServer:
                 ).first()
                 if not trigger:
                     raise HTTPException(status_code=404, detail="Trigger not found")
+
+                # Block converting a working trigger into an unfireable type. A row
+                # already stored as one may still be saved unchanged, so a legacy
+                # trigger can be renamed or — the point — disabled.
+                new_type = body.get("trigger_type")
+                if (new_type in UNIMPLEMENTED_TRIGGER_TYPES
+                        and new_type != trigger.trigger_type):
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"trigger_type '{new_type}' is not implemented and would never fire. "
+                               "Use 'cron' or 'webhook'.",
+                    )
 
                 for field in ("name", "description", "trigger_type", "agent_name", "prompt",
                               "cron_expression", "output_type"):

--- a/shared/utils/trigger_runner.py
+++ b/shared/utils/trigger_runner.py
@@ -40,6 +40,11 @@ def get_trigger_runner() -> "TriggerRunner":
 # POST costs a truncated placeholder, not an unbounded token bill.
 MAX_PAYLOAD_CHARS = 4000
 
+# Stored and loadable, but nothing ever fires them (see _execute_trigger_sync).
+# Creating one is therefore always a mistake, so the API refuses it. Existing
+# rows keep loading and listing — removing them is the operator's call, not ours.
+UNIMPLEMENTED_TRIGGER_TYPES = ("file_watch", "event_bus")
+
 _PAYLOAD_PLACEHOLDER = re.compile(r"\{\{\s*payload(?:\.([A-Za-z0-9_.\-]+))?\s*\}\}")
 
 
@@ -359,7 +364,7 @@ class TriggerRunner:
 
         Cron firings pass no payload; the prompt then renders unchanged.
         """
-        if trigger.trigger_type in ("file_watch", "event_bus"):
+        if trigger.trigger_type in UNIMPLEMENTED_TRIGGER_TYPES:
             logger.info("Trigger %s type='%s' — not yet implemented", trigger.id, trigger.trigger_type)
             return {"status": "skipped", "message": f"trigger_type '{trigger.trigger_type}' not yet implemented"}
 

--- a/templates/dashboard/modals/trigger_modal.html
+++ b/templates/dashboard/modals/trigger_modal.html
@@ -26,8 +26,11 @@
                             class="mt-1 block w-full border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded px-2 py-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-blue-500">
                             <option value="cron">Cron (schedule)</option>
                             <option value="webhook">Webhook (HTTP POST)</option>
-                            <option value="file_watch">File Watch ⚠ stub</option>
-                            <option value="event_bus">Event Bus ⚠ stub</option>
+                            <!-- Disabled, not removed: a legacy row of this type must still
+                                 display its real type when edited. Removing the option would
+                                 make the select fall back to "cron" and silently convert it. -->
+                            <option value="file_watch" disabled>File Watch (not implemented)</option>
+                            <option value="event_bus" disabled>Event Bus (not implemented)</option>
                         </select>
                     </div>
                 </div>
@@ -98,7 +101,9 @@
                     <div class="bg-yellow-50 dark:bg-yellow-900 border border-yellow-200 dark:border-yellow-700 rounded px-3 py-2">
                         <p class="text-xs text-yellow-800 dark:text-yellow-200">
                             <i class="fas fa-exclamation-triangle mr-1"></i>
-                            This trigger type is not yet implemented. The trigger will be saved but will return a "not yet implemented" status when fired.
+                            This trigger type is not implemented — it never fires. New triggers of
+                            this type are refused; this existing one can still be renamed or
+                            disabled, but it will not run until the type is implemented.
                         </p>
                     </div>
                 </div>


### PR DESCRIPTION
Closes #76. One commit.

## The problem

`file_watch` and `event_bus` are accepted by the model and offered in the dashboard, but `_execute_trigger_sync` skips them with "not yet implemented". A user could save a trigger that looks like automation and silently never runs.

**One correction to the issue:** it said there was no warning at creation time. There was — the dropdown already labelled both "⚠ stub" and a warning banner already existed. The real problem is that a warning is the wrong instrument here. It explains why the thing you are about to save will not work, and then saves it anyway.

## The fix

**Creation is refused with 400 at the API.** That is where it belongs — the dashboard is not the only caller, and a UI-only change leaves the hole open to anything hitting the endpoint directly.

**The UI options are disabled, not deleted.** Removing them would leave a legacy row's type absent from the `<select>`, so opening it for edit would fall back to "cron" and a save would silently convert a stored `file_watch` trigger into a scheduled one — turning a dead trigger into a live one nobody asked for. A disabled option still displays when set programmatically, so the row shows its real type and cannot be picked for a new trigger.

**Update blocks conversion but permits saving a row already stored as one.** Blocking that outright would trap operators: the update path is how a dead legacy trigger gets disabled, which is the one thing anyone actually wants to do with it.

The pair now lives in one constant, `UNIMPLEMENTED_TRIGGER_TYPES`, so the runner's skip and the API's refusal cannot drift apart.

## Verification

725 tests pass, 7 new — refusal for both types, nothing stored on refusal, `cron`/`webhook` unaffected, conversion refused, legacy row still lists, legacy row can still be disabled, legacy row still fires-as-skipped.

Live against the running server:

| Action | Result |
|---|---|
| Create `file_watch` | 400, nothing stored |
| Create `cron` | 200 |
| Legacy `file_watch` row lists | yes, shows real type |
| Disable legacy row | 200, `is_enabled=0`, type preserved |
| Convert `cron` → `file_watch` | 400, row unchanged |

No migration — existing rows are untouched, and deleting them stays the operator's decision.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ToCUNy2SqwvfTq4a6xfSk1)_