### PR TITLE
fix(agents): warn when a database agent is built without a description

### DIFF
--- a/shared/test/test_agent_description_warning.py
+++ b/shared/test/test_agent_description_warning.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""
+Tests that building a database agent with no description is logged (#79).
+
+`description` is nullable on agents_config and nothing in the dashboard or the
+API requires it, so an agent with an empty one is a normal reachable state. ADK
+uses that field as the routing signal when a parent LLM agent picks a sub-agent
+to delegate to, so an empty one degrades delegation silently: the agent is
+constructed, appears in the tree, and is simply never routed to. These tests pin
+the warning that makes it visible at startup instead of at delegation time.
+"""
+
+import unittest
+from unittest.mock import Mock, patch
+import sys
+import os
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from shared.utils.agent_manager import AgentManager
+
+LOGGER = 'shared.utils.agent_manager'
+
+
+class TestEmptyDescriptionWarning(unittest.TestCase):
+
+    def setUp(self):
+        self.agent_manager = AgentManager()
+        self.mock_db_client = Mock()
+        self.agent_manager.db_client = self.mock_db_client
+        self.mock_session = Mock()
+        self.mock_db_client.get_session.return_value = self.mock_session
+
+    def tearDown(self):
+        self.agent_manager.clear_initialized_agents()
+
+    def _config(self, **overrides):
+        config = {
+            'name': 'test_agent',
+            'type': 'llm',
+            'description': 'A useful description',
+            'instruction': 'Test instruction',
+            'model_name': 'test-model',
+            'tool_config': None,
+            'max_iterations': None,
+            'allowed_for_roles': [],
+            'planner_config': None,
+        }
+        config.update(overrides)
+        return config
+
+    def _warnings(self, records):
+        return [r.getMessage() for r in records
+                if r.levelname == 'WARNING' and 'has no description' in r.getMessage()]
+
+    # -- warns ------------------------------------------------------------- #
+
+    @patch('shared.utils.tools.tool_factory.ToolFactory')
+    @patch('shared.utils.utils.create_model')
+    def test_agent_with_sub_agents_and_no_description_warns(self, mock_create_model, mock_tool_factory):
+        mock_tool_factory.return_value.create_tools.return_value = []
+        mock_create_model.return_value = 'gemini-2.0-flash'
+        from google.adk.workflow import Node
+        config = self._config(name='parent_agent', type='graph', description=None)
+
+        with self.assertLogs(LOGGER, level='WARNING') as ctx:
+            result = self.agent_manager._initialize_agent(config, [Node(name='child')])
+
+        warnings = self._warnings(ctx.records)
+        self.assertEqual(len(warnings), 1)
+        self.assertIn('parent_agent', warnings[0])
+        # The agent is still built — this is a warning, not a rejection.
+        self.assertIsNotNone(result)
+        self.assertEqual(result.name, 'parent_agent')
+
+    @patch('shared.utils.tools.tool_factory.ToolFactory')
+    @patch('shared.utils.utils.create_model')
+    def test_agent_that_is_itself_a_sub_agent_warns(self, mock_create_model, mock_tool_factory):
+        mock_tool_factory.return_value.create_tools.return_value = []
+        mock_create_model.return_value = 'gemini-2.0-flash'
+        # No children of its own, but a parent needs a description to route to it.
+        config = self._config(name='child_agent', description='', parent_agents=['parent_agent'])
+
+        with self.assertLogs(LOGGER, level='WARNING') as ctx:
+            result = self.agent_manager._initialize_agent(config, [])
+
+        warnings = self._warnings(ctx.records)
+        self.assertEqual(len(warnings), 1)
+        self.assertIn('child_agent', warnings[0])
+        self.assertIsNotNone(result)
+
+    # -- stays quiet ------------------------------------------------------- #
+
+    @patch('shared.utils.tools.tool_factory.ToolFactory')
+    @patch('shared.utils.utils.create_model')
+    def test_lone_root_agent_with_no_description_does_not_warn(self, mock_create_model, mock_tool_factory):
+        mock_tool_factory.return_value.create_tools.return_value = []
+        mock_create_model.return_value = 'gemini-2.0-flash'
+        # Nothing delegates to it and it delegates nowhere, so there is no
+        # routing decision to degrade. Warning here would be noise on every start.
+        config = self._config(name='lone_agent', description=None, parent_agents=[])
+
+        with self.assertLogs(LOGGER, level='DEBUG') as ctx:
+            self.agent_manager._initialize_agent(config, [])
+
+        self.assertEqual(self._warnings(ctx.records), [])
+
+    @patch('shared.utils.tools.tool_factory.ToolFactory')
+    @patch('shared.utils.utils.create_model')
+    def test_agent_with_a_description_does_not_warn(self, mock_create_model, mock_tool_factory):
+        mock_tool_factory.return_value.create_tools.return_value = []
+        mock_create_model.return_value = 'gemini-2.0-flash'
+        config = self._config(name='described_agent', parent_agents=['parent_agent'])
+
+        with self.assertLogs(LOGGER, level='DEBUG') as ctx:
+            result = self.agent_manager._initialize_agent(config, [])
+
+        self.assertEqual(self._warnings(ctx.records), [])
+        self.assertEqual(result.description, 'A useful description')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/shared/utils/agent_manager.py
+++ b/shared/utils/agent_manager.py
@@ -367,7 +367,17 @@ class AgentManager:
             description = config.get('description') or ''
             instruction = config.get('instruction') or ''
             sub_agents = sub_agents or []
-            
+
+            # ADK picks a sub-agent to delegate to by reading descriptions, so an
+            # agent inside a tree with an empty one is reachable but never routed
+            # to — silently, at delegation time. Surface it at build time instead.
+            # A lone root agent delegates nowhere, so it is not worth a warning.
+            if not description and (sub_agents or config.get('parent_agents')):
+                logger.warning(
+                    f"Agent '{agent_name}' has no description. ADK routes to sub-agents "
+                    f"on their description, so a parent has nothing to delegate on here."
+                )
+
             # Parse input_schema if present and convert to Pydantic model
             input_schema = None
             input_schema_config = config.get('input_schema')


### PR DESCRIPTION
Closes #79

## Problem

`AgentManager._initialize_agent` falls back to an empty string when a database-backed agent config has no description, and passes it straight to the constructor for every agent type.

ADK uses `description` as the routing signal when a parent LLM agent decides which sub-agent to delegate to. An agent built with `description=''` still constructs, still appears in the tree, but the parent has nothing to route on — so delegation to it degrades silently. No error, no log line, nothing in the dashboard.

`description` is `nullable=True` on `agents_config` and nothing in the dashboard or API requires it, so this is a normal reachable state rather than an edge case.

## Change

Option 1 from the issue: log a warning at build time in `shared/utils/agent_manager.py`, right where the fallback happens, so the problem surfaces at startup instead of at delegation time.

The warning is scoped to agents that have sub-agents or are themselves sub-agents — both directions named in the issue. A lone root agent delegates nowhere and would only add noise to every start.

Deliberately **not** included: a derived fallback description (option 2) would steer ADK's routing with invented text nobody asked for, and a dashboard validation warning (option 3) is a separate frontend change. Behaviour is otherwise unchanged — nothing is rejected, nothing is rewritten.

## Tests

New `shared/test/test_agent_description_warning.py` (4 tests):

- agent with sub-agents and no description → warns, and still builds
- agent that is itself a sub-agent with no description → warns
- lone root agent with no description → stays quiet
- agent with a description → stays quiet

Full suite: 729 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)