### PR TITLE
feat(triggers): verify HMAC signatures on inbound webhooks

### DIFF
--- a/documents/TRIGGERS.md
+++ b/documents/TRIGGERS.md
@@ -35,13 +35,18 @@ The scheduler uses APScheduler's `BackgroundScheduler` with `coalesce=True` — 
 curl -X POST https://your-mate.example.com/triggers/{trigger_id}/fire \
   -H "X-MATE-Trigger-Key: <fire_key>"
 
-# With fire key query param
+# With fire key query param (deprecated — see below)
 curl -X POST "https://your-mate.example.com/triggers/{trigger_id}/fire?key=<fire_key>"
 
 # With standard dashboard credentials (bearer token)
 curl -X POST https://your-mate.example.com/triggers/{trigger_id}/fire \
   -H "Authorization: Bearer <token>"
 ```
+
+> **`?key=` is deprecated.** A secret in the URL lands in access logs, proxy logs and browser
+> history, where it outlives any rotation you meant it to have. It still works and fires a
+> warning in the server log; use the `X-MATE-Trigger-Key` header, or sign the request and drop
+> the query param entirely.
 
 ### Using the request body in the prompt
 
@@ -84,12 +89,66 @@ Notes:
 > straight into an agent prompt. Enable the `prompt_injection` guardrail on any agent whose
 > trigger interpolates a payload, and keep the trigger's output destination narrow.
 
+### Verifying signatures (optional)
+
+A fire key authenticates the *caller*; it cannot prove who composed the *body*. Anyone who has
+ever seen the key — a proxy log, a CI variable, a screenshot of the one-time banner — can forge
+any payload, and since the body reaches the agent's prompt, that is a prompt-injection surface
+on an endpoint designed to be called by third parties. A signature binds the body to the sender;
+a shared key does not. This is why GitHub, GitLab, Jira and Stripe all sign.
+
+Turn it on per trigger: open the trigger edit modal and tick **Require signed requests**, or
+`PUT /dashboard/api/triggers/{id}` with `{"require_signature": true}`. It is **off by default**,
+so existing callers keep working unchanged.
+
+Each webhook trigger gets a **signing secret** alongside its fire key, shown once in the same
+dashboard banner. To rotate it, click **Regenerate Signing Secret** — senders on the old secret
+start failing immediately.
+
+The signature is `HMAC-SHA256(signing_secret, raw_request_body)`, hex-encoded, sent in either
+header:
+
+| Header | Format | Sent by |
+|---|---|---|
+| `X-Hub-Signature-256` | `sha256=<hex>` | GitHub, GitLab |
+| `X-MATE-Signature` | `<hex>` | MATE-native callers |
+
+`X-Hub-Signature-256` is checked first. Verification runs over the raw bytes, **before** the body
+is parsed as JSON, and the comparison is constant-time.
+
+```bash
+BODY='{"key":"MT-32","action":"updated"}'
+SIG=$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "$SIGNING_SECRET" | awk '{print $2}')
+
+curl -X POST https://your-mate.example.com/triggers/7/fire \
+  -H "X-MATE-Trigger-Key: $FIRE_KEY" \
+  -H "X-Hub-Signature-256: sha256=$SIG" \
+  -H "Content-Type: application/json" \
+  -d "$BODY"
+```
+
+For GitHub or GitLab, paste the signing secret into the webhook's **Secret** field — they compute
+`X-Hub-Signature-256` themselves.
+
+Notes:
+
+- When verification is required, a missing or wrong signature is rejected **401**, and a valid
+  fire key on its own is not sufficient.
+- Triggers without it enabled behave exactly as before — no signature is looked for.
+- Sign the exact bytes you send. Re-serialising parsed JSON reorders keys and changes whitespace,
+  which changes the digest.
+- **No replay protection.** A captured signed request can be replayed, since there is no
+  timestamp or nonce window. Keep the trigger's output destination narrow, and treat a signed
+  body as authentic, not as fresh.
+
 ### Fire key lifecycle
 
 - A **fire key** is generated when you create a webhook trigger. It is shown **once** in a dashboard banner — copy it immediately.
 - The raw key is never stored; only its SHA-256 hash is kept in the database.
 - To rotate the key: open the trigger edit modal and click **Regenerate Key**. The old key is invalidated immediately.
 - If you lose your fire key, regenerate it — there is no recovery.
+- The **signing secret** is separate and rotates separately. Unlike the fire key it is stored in
+  the clear, because verifying a signature means recomputing it and a hash could not.
 
 ## Output Destinations
 

--- a/shared/sql/migrations/mysql/V029__trigger_signatures.sql
+++ b/shared/sql/migrations/mysql/V029__trigger_signatures.sql
@@ -1,0 +1,6 @@
+-- Migration: Optional HMAC signature verification on webhook triggers
+-- Version: V029
+-- Database: MySQL
+
+ALTER TABLE agent_triggers ADD COLUMN IF NOT EXISTS signing_secret VARCHAR(255);
+ALTER TABLE agent_triggers ADD COLUMN IF NOT EXISTS require_signature TINYINT(1) NOT NULL DEFAULT 0;

--- a/shared/sql/migrations/postgresql/V029__trigger_signatures.sql
+++ b/shared/sql/migrations/postgresql/V029__trigger_signatures.sql
@@ -1,0 +1,6 @@
+-- Migration: Optional HMAC signature verification on webhook triggers
+-- Version: V029
+-- Database: PostgreSQL
+
+ALTER TABLE agent_triggers ADD COLUMN IF NOT EXISTS signing_secret VARCHAR(255);
+ALTER TABLE agent_triggers ADD COLUMN IF NOT EXISTS require_signature BOOLEAN NOT NULL DEFAULT FALSE;

--- a/shared/sql/migrations/sqlite/V029__trigger_signatures.sql
+++ b/shared/sql/migrations/sqlite/V029__trigger_signatures.sql
@@ -1,0 +1,6 @@
+-- Migration: Optional HMAC signature verification on webhook triggers
+-- Version: V029
+-- Database: SQLite
+
+ALTER TABLE agent_triggers ADD COLUMN signing_secret VARCHAR(255);
+ALTER TABLE agent_triggers ADD COLUMN require_signature BOOLEAN NOT NULL DEFAULT 0;

--- a/shared/test/test_trigger_payload.py
+++ b/shared/test/test_trigger_payload.py
@@ -116,7 +116,7 @@ class TestFireEndpointReadsTheBody(unittest.TestCase):
             app = FastAPI()
             server = DashboardServer(app, project_root)
 
-        trigger_row = MagicMock(id=7, fire_key_hash=None)
+        trigger_row = MagicMock(id=7, fire_key_hash=None, require_signature=False)
         session = MagicMock()
         session.query.return_value.filter.return_value.first.return_value = trigger_row
         server.db_client = MagicMock()

--- a/shared/test/test_trigger_signature.py
+++ b/shared/test/test_trigger_signature.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""
+Tests for optional HMAC verification on inbound trigger webhooks (#83).
+
+`POST /triggers/{id}/fire` authenticates with a shared fire key. Since #75 the
+body is interpolated into the agent's prompt through `{{ payload }}`, so whoever
+holds the key controls text that goes straight into an LLM — and a bearer secret
+cannot prove who composed a body. These tests pin the signature check: that it
+runs over the raw bytes before parsing, that a valid fire key alone is refused
+once verification is required, and that triggers without it behave exactly as
+they did before.
+"""
+
+import hashlib
+import hmac
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from shared.utils.models import AgentTrigger
+from shared.utils.trigger_runner import TriggerRunner
+
+SECRET = "whsec_test_secret"
+FIRE_KEY = "raw-fire-key"
+FIRE_KEY_HASH = hashlib.sha256(FIRE_KEY.encode()).hexdigest()
+
+
+def sign(body: bytes, secret: str = SECRET) -> str:
+    return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+class TestVerifySignature(unittest.TestCase):
+    """Unit-level checks on the helper itself."""
+
+    def test_bare_hex_digest_is_accepted(self):
+        body = b'{"a":1}'
+        self.assertTrue(TriggerRunner.verify_signature(SECRET, body, sign(body)))
+
+    def test_github_style_prefix_is_accepted(self):
+        body = b'{"a":1}'
+        self.assertTrue(
+            TriggerRunner.verify_signature(SECRET, body, "sha256=" + sign(body)))
+
+    def test_uppercase_digest_is_accepted(self):
+        body = b'{"a":1}'
+        self.assertTrue(
+            TriggerRunner.verify_signature(SECRET, body, sign(body).upper()))
+
+    def test_a_different_body_does_not_verify(self):
+        self.assertFalse(
+            TriggerRunner.verify_signature(SECRET, b'{"a":2}', sign(b'{"a":1}')))
+
+    def test_a_different_secret_does_not_verify(self):
+        body = b'{"a":1}'
+        self.assertFalse(
+            TriggerRunner.verify_signature(SECRET, body, sign(body, "other")))
+
+    def test_missing_secret_or_signature_does_not_verify(self):
+        self.assertFalse(TriggerRunner.verify_signature("", b"x", sign(b"x")))
+        self.assertFalse(TriggerRunner.verify_signature(SECRET, b"x", ""))
+        self.assertFalse(TriggerRunner.verify_signature(SECRET, b"x", None))
+
+    def test_empty_body_still_signs(self):
+        # A webhook that fires with nothing is normal; it must still be signable.
+        self.assertTrue(TriggerRunner.verify_signature(SECRET, b"", sign(b"")))
+
+    def test_comparison_is_constant_time(self):
+        body = b'{"a":1}'
+        with patch("shared.utils.trigger_runner.hmac.compare_digest",
+                   wraps=hmac.compare_digest) as cmp:
+            TriggerRunner.verify_signature(SECRET, body, sign(body))
+        cmp.assert_called_once()
+
+    def test_generated_secrets_are_unique_and_prefixed(self):
+        a, b = TriggerRunner.generate_signing_secret(), TriggerRunner.generate_signing_secret()
+        self.assertNotEqual(a, b)
+        self.assertTrue(a.startswith("whsec_"))
+
+
+class FireEndpointTestCase(unittest.TestCase):
+    """Drives the real /triggers/{id}/fire route against a stubbed trigger row."""
+
+    require_signature = True
+
+    def setUp(self):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from shared.utils.dashboard.dashboard_server import DashboardServer
+
+        with patch("shared.utils.database_client.get_database_client",
+                   return_value=MagicMock()):
+            project_root = Path(os.path.dirname(os.path.dirname(
+                os.path.dirname(os.path.abspath(__file__)))))
+            app = FastAPI()
+            self.server = DashboardServer(app, project_root)
+
+        trigger_row = MagicMock(
+            id=7,
+            fire_key_hash=FIRE_KEY_HASH,
+            signing_secret=SECRET,
+            require_signature=self.require_signature,
+        )
+        session = MagicMock()
+        session.query.return_value.filter.return_value.first.return_value = trigger_row
+        self.server.db_client = MagicMock()
+        self.server.db_client.get_session.return_value = session
+
+        self.runner = MagicMock()
+        self.runner.execute_trigger.return_value = {"status": "ok", "agent_response": "x"}
+        self.patchers = [
+            patch("shared.utils.trigger_runner.get_trigger_runner", return_value=self.runner),
+            patch("server.auth.require_dashboard_auth", return_value=True),
+        ]
+        for p in self.patchers:
+            p.start()
+        self.client = TestClient(app)
+
+    def tearDown(self):
+        for p in self.patchers:
+            p.stop()
+
+    def fire(self, body: bytes = b'{"key":"MT-32"}', headers=None, key=FIRE_KEY):
+        headers = dict(headers or {})
+        headers["Content-Type"] = "application/json"
+        if key:
+            headers["X-MATE-Trigger-Key"] = key
+        return self.client.post("/triggers/7/fire", content=body, headers=headers)
+
+
+class TestSignatureRequired(FireEndpointTestCase):
+
+    require_signature = True
+
+    def test_github_header_is_accepted(self):
+        body = b'{"key":"MT-32"}'
+        resp = self.fire(body, {"X-Hub-Signature-256": "sha256=" + sign(body)})
+        self.assertEqual(resp.status_code, 200)
+        self.runner.execute_trigger.assert_called_once_with(7, {"key": "MT-32"})
+
+    def test_mate_native_header_is_accepted(self):
+        body = b'{"key":"MT-32"}'
+        resp = self.fire(body, {"X-MATE-Signature": sign(body)})
+        self.assertEqual(resp.status_code, 200)
+
+    def test_a_wrong_signature_is_rejected(self):
+        resp = self.fire(b'{"key":"MT-32"}', {"X-MATE-Signature": sign(b'{"key":"other"}')})
+        self.assertEqual(resp.status_code, 401)
+        self.runner.execute_trigger.assert_not_called()
+
+    def test_a_valid_fire_key_without_a_signature_is_rejected(self):
+        # The whole point: the key authenticates the caller, it does not prove
+        # who composed the body that reaches the prompt.
+        resp = self.fire(b'{"key":"MT-32"}')
+        self.assertEqual(resp.status_code, 401)
+        self.assertIn("Signature required", resp.json()["detail"])
+        self.runner.execute_trigger.assert_not_called()
+
+    def test_dashboard_auth_without_a_signature_is_rejected(self):
+        resp = self.fire(b'{"key":"MT-32"}', key=None)
+        self.assertEqual(resp.status_code, 401)
+        self.runner.execute_trigger.assert_not_called()
+
+    def test_verification_runs_over_the_raw_body_before_parsing(self):
+        # Not valid JSON: it reaches the signature check first and passes it, so
+        # the trigger still fires with no payload rather than failing to verify.
+        body = b'not json at all'
+        resp = self.fire(body, {"X-MATE-Signature": sign(body)})
+        self.assertEqual(resp.status_code, 200)
+        self.runner.execute_trigger.assert_called_once_with(7, None)
+
+    def test_a_resigned_reserialisation_of_the_same_json_is_still_the_raw_bytes(self):
+        # Signing the bytes actually sent is what is checked — a digest over
+        # re-serialised JSON (different whitespace) must not pass.
+        body = b'{"key": "MT-32"}'
+        reserialised = json.dumps(json.loads(body), separators=(",", ":")).encode()
+        self.assertNotEqual(body, reserialised)
+        resp = self.fire(body, {"X-MATE-Signature": sign(reserialised)})
+        self.assertEqual(resp.status_code, 401)
+
+
+class TestSignatureNotRequired(FireEndpointTestCase):
+    """Triggers without it enabled must behave exactly as they did before."""
+
+    require_signature = False
+
+    def test_fire_key_alone_still_works(self):
+        resp = self.fire(b'{"key":"MT-32"}')
+        self.assertEqual(resp.status_code, 200)
+        self.runner.execute_trigger.assert_called_once_with(7, {"key": "MT-32"})
+
+    def test_an_unsigned_body_is_not_examined(self):
+        resp = self.fire(b'{"key":"MT-32"}', {"X-MATE-Signature": "garbage"})
+        self.assertEqual(resp.status_code, 200)
+
+    def test_a_wrong_fire_key_is_still_refused(self):
+        resp = self.fire(b'{"key":"MT-32"}', key="wrong-key")
+        self.assertEqual(resp.status_code, 403)
+
+    def test_dashboard_auth_still_works(self):
+        resp = self.fire(b'{"key":"MT-32"}', key=None)
+        self.assertEqual(resp.status_code, 200)
+
+
+class TestTriggerSerialisation(unittest.TestCase):
+
+    def test_to_dict_never_leaks_the_signing_secret(self):
+        trigger = AgentTrigger(
+            name="t", trigger_type="webhook", agent_name="a", project_id=1,
+            prompt="p", signing_secret=SECRET, require_signature=True,
+        )
+        payload = trigger.to_dict()
+        self.assertNotIn("signing_secret", payload)
+        self.assertNotIn(SECRET, json.dumps(payload))
+        # The dashboard still needs to know a secret exists and whether it is used.
+        self.assertTrue(payload["has_signing_secret"])
+        self.assertTrue(payload["require_signature"])
+
+    def test_a_trigger_without_a_secret_reports_so(self):
+        trigger = AgentTrigger(name="t", trigger_type="cron", agent_name="a",
+                               project_id=1, prompt="p")
+        payload = trigger.to_dict()
+        self.assertFalse(payload["has_signing_secret"])
+        self.assertFalse(payload["require_signature"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/shared/utils/dashboard/dashboard_server.py
+++ b/shared/utils/dashboard/dashboard_server.py
@@ -6343,7 +6343,11 @@ class DashboardServer:
             request: Request,
             username: str = Depends(self._get_auth_user_dependency),
         ):
-            """Create a new trigger. Returns trigger + fire_key (webhook triggers only, shown once)."""
+            """Create a new trigger.
+
+            Returns trigger + fire_key and signing_secret (webhook triggers only,
+            both shown once).
+            """
             import re as _re
             import secrets as _secrets
             from shared.utils.trigger_runner import (
@@ -6368,6 +6372,7 @@ class DashboardServer:
             try:
                 raw_fire_key = None
                 fire_key_hash = None
+                signing_secret = None
                 webhook_path = None
 
                 if trigger_type == "webhook":
@@ -6382,6 +6387,9 @@ class DashboardServer:
                             break
                         webhook_path = generate_webhook_path(name)
                     raw_fire_key, fire_key_hash = get_trigger_runner().generate_fire_key()
+                    # Always minted, so enabling verification later needs no
+                    # rotation dance — it is simply not used until asked for.
+                    signing_secret = get_trigger_runner().generate_signing_secret()
 
                 trigger = self.AgentTrigger(
                     name=body.get("name", "").strip(),
@@ -6393,6 +6401,8 @@ class DashboardServer:
                     cron_expression=body.get("cron_expression"),
                     webhook_path=webhook_path,
                     fire_key_hash=fire_key_hash,
+                    signing_secret=signing_secret,
+                    require_signature=bool(body.get("require_signature", False)),
                     output_type=body.get("output_type", "memory_block"),
                     is_enabled=body.get("is_enabled", True),
                     created_by=username,
@@ -6405,6 +6415,8 @@ class DashboardServer:
                 result = {"trigger": trigger.to_dict()}
                 if raw_fire_key:
                     result["fire_key"] = raw_fire_key
+                if signing_secret:
+                    result["signing_secret"] = signing_secret
                 return result
             except Exception as e:
                 session.rollback()
@@ -6419,7 +6431,11 @@ class DashboardServer:
             request: Request,
             username: str = Depends(self._get_auth_user_dependency),
         ):
-            """Update a trigger. Pass regenerate_fire_key=true to rotate the webhook key."""
+            """Update a trigger.
+
+            Pass regenerate_fire_key=true to rotate the webhook key, or
+            regenerate_signing_secret=true to rotate the body-signing secret.
+            """
             from shared.utils.trigger_runner import UNIMPLEMENTED_TRIGGER_TYPES, get_trigger_runner
 
             if not self.db_client:
@@ -6455,6 +6471,8 @@ class DashboardServer:
                     trigger.project_id = int(body["project_id"])
                 if "is_enabled" in body:
                     trigger.is_enabled = bool(body["is_enabled"])
+                if "require_signature" in body:
+                    trigger.require_signature = bool(body["require_signature"])
                 if "output_config" in body:
                     trigger.set_output_config(body["output_config"] or {})
 
@@ -6462,12 +6480,24 @@ class DashboardServer:
                 if body.get("regenerate_fire_key") and trigger.trigger_type == "webhook":
                     raw_fire_key, trigger.fire_key_hash = get_trigger_runner().generate_fire_key()
 
+                signing_secret = None
+                if trigger.trigger_type == "webhook" and (
+                    body.get("regenerate_signing_secret")
+                    # A trigger created before signing existed has no secret, so
+                    # turning verification on has to mint one or nothing can pass.
+                    or (trigger.require_signature and not trigger.signing_secret)
+                ):
+                    signing_secret = get_trigger_runner().generate_signing_secret()
+                    trigger.signing_secret = signing_secret
+
                 session.commit()
                 session.refresh(trigger)
                 get_trigger_runner().sync_cron_jobs()
                 result = {"trigger": trigger.to_dict()}
                 if raw_fire_key:
                     result["fire_key"] = raw_fire_key
+                if signing_secret:
+                    result["signing_secret"] = signing_secret
                 return result
             except HTTPException:
                 raise
@@ -6718,30 +6748,49 @@ class DashboardServer:
             """
             Webhook fire endpoint — authenticate with X-MATE-Trigger-Key header,
             ?key= query param, or standard dashboard bearer/basic auth.
+
+            A trigger may additionally require the body to be signed; see
+            documents/TRIGGERS.md.
             """
             from shared.utils.trigger_runner import get_trigger_runner, TriggerRunner
 
             if not self.db_client:
                 raise HTTPException(status_code=500, detail="Database unavailable")
 
+            # Read the raw body before anything parses it: the signature is over
+            # exactly these bytes, and re-serialising parsed JSON would not
+            # reproduce them. Starlette caches it, so request.json() still works.
+            raw_body = await request.body()
+
+            session = self.db_client.get_session()
+            if not session:
+                raise HTTPException(status_code=500, detail="Database unavailable")
+            try:
+                trigger_row = session.query(self.AgentTrigger).filter(
+                    self.AgentTrigger.id == trigger_id
+                ).first()
+                fire_key_hash = trigger_row.fire_key_hash if trigger_row else None
+                signing_secret = trigger_row.signing_secret if trigger_row else None
+                require_signature = bool(trigger_row.require_signature) if trigger_row else False
+            finally:
+                session.close()
+
             # 1. Try fire key auth first (for external callers)
-            raw_key = (
-                request.headers.get("X-MATE-Trigger-Key")
-                or request.query_params.get("key")
-            )
+            raw_key = request.headers.get("X-MATE-Trigger-Key")
+            if not raw_key:
+                raw_key = request.query_params.get("key")
+                if raw_key:
+                    # Deprecated: a query param lands in access logs, proxy logs
+                    # and browser history. Still honoured, but say so.
+                    logger.warning(
+                        "Trigger %s fired with ?key= — the secret ends up in access "
+                        "logs and browser history. Use the X-MATE-Trigger-Key header "
+                        "or a signed request instead.", trigger_id
+                    )
             authed = False
             if raw_key:
-                session = self.db_client.get_session()
-                if not session:
-                    raise HTTPException(status_code=500, detail="Database unavailable")
-                try:
-                    trigger_row = session.query(self.AgentTrigger).filter(
-                        self.AgentTrigger.id == trigger_id
-                    ).first()
-                    if trigger_row and trigger_row.fire_key_hash:
-                        authed = TriggerRunner.verify_fire_key(raw_key, trigger_row.fire_key_hash)
-                finally:
-                    session.close()
+                if fire_key_hash:
+                    authed = TriggerRunner.verify_fire_key(raw_key, fire_key_hash)
                 if not authed:
                     raise HTTPException(status_code=403, detail="Invalid trigger key")
             else:
@@ -6755,6 +6804,22 @@ class DashboardServer:
                         status_code=403,
                         detail="Authentication required: provide X-MATE-Trigger-Key header or dashboard credentials",
                     )
+
+            # 3. A bearer secret proves nothing about who composed the body, and
+            # since the body reaches the prompt, that matters. When the trigger
+            # requires it, a valid fire key on its own is not enough.
+            if require_signature:
+                signature = (
+                    request.headers.get("X-Hub-Signature-256")
+                    or request.headers.get("X-MATE-Signature")
+                )
+                if not signature:
+                    raise HTTPException(
+                        status_code=401,
+                        detail="Signature required: send X-Hub-Signature-256 or X-MATE-Signature",
+                    )
+                if not TriggerRunner.verify_signature(signing_secret, raw_body, signature):
+                    raise HTTPException(status_code=401, detail="Invalid signature")
 
             # The firing system's body reaches the prompt through {{ payload }}.
             # A body that is absent or not JSON is not an error: plenty of

--- a/shared/utils/models.py
+++ b/shared/utils/models.py
@@ -1091,6 +1091,11 @@ class AgentTrigger(Base):
     cron_expression = Column(String(100), nullable=True)
     webhook_path = Column(String(255), nullable=True, unique=True)
     fire_key_hash = Column(String(255), nullable=True)
+    # HMAC secret for signing the request body. Unlike the fire key this is
+    # stored in the clear — verifying a signature means recomputing it, so a
+    # hash would not do. Never returned by to_dict().
+    signing_secret = Column(String(255), nullable=True)
+    require_signature = Column(Boolean, nullable=False, default=False)
     output_type = Column(String(50), nullable=False, default='memory_block')
     output_config = Column(Text, nullable=True)
     is_enabled = Column(Boolean, nullable=False, default=True)
@@ -1132,6 +1137,9 @@ class AgentTrigger(Base):
             'prompt': self.prompt,
             'cron_expression': self.cron_expression,
             'webhook_path': self.webhook_path,
+            'require_signature': bool(self.require_signature),
+            # The secret itself is shown once at creation and never again.
+            'has_signing_secret': bool(self.signing_secret),
             'output_type': self.output_type,
             'output_config': self.get_output_config(),
             'is_enabled': self.is_enabled,

--- a/shared/utils/trigger_runner.py
+++ b/shared/utils/trigger_runner.py
@@ -7,6 +7,7 @@ file_watch and event_bus triggers are stored in DB but log "not yet implemented"
 """
 
 import hashlib
+import hmac
 import json
 import logging
 import os
@@ -107,6 +108,8 @@ class TriggerRunner:
       - execute_trigger(trigger_id) — run one trigger (webhook fire or test-fire)
       - generate_fire_key()         — create a raw key + its SHA-256 hash
       - verify_fire_key(raw, hash)  — constant-time key verification
+      - generate_signing_secret()   — create a webhook body-signing secret
+      - verify_signature(...)       — constant-time HMAC check over the raw body
     """
 
     def __init__(self) -> None:
@@ -540,3 +543,31 @@ class TriggerRunner:
             hashlib.sha256(raw.encode()).hexdigest(),
             stored_hash,
         )
+
+    # ------------------------------------------------------------------ #
+    # Body signature helpers                                              #
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def generate_signing_secret() -> str:
+        """Return a webhook signing secret. Stored in the clear — see the model."""
+        return f"whsec_{secrets.token_urlsafe(32)}"
+
+    @staticmethod
+    def verify_signature(secret: str, raw_body: bytes, signature: str) -> bool:
+        """Constant-time HMAC-SHA256 check of a signature over the raw request body.
+
+        Accepts both shapes real senders use: `sha256=<hex>` as GitHub and GitLab
+        send in X-Hub-Signature-256, and a bare hex digest for MATE's own
+        X-MATE-Signature. Mirrors the Slack verifier in server/slack_routes.py,
+        minus the timestamp window — replay protection is a separate concern.
+        """
+        if not secret or not signature:
+            return False
+        candidate = signature.strip()
+        if candidate.lower().startswith("sha256="):
+            candidate = candidate[len("sha256="):]
+        computed = hmac.new(
+            secret.encode("utf-8"), raw_body or b"", hashlib.sha256
+        ).hexdigest()
+        return hmac.compare_digest(computed, candidate.lower())

--- a/static/js/triggers-page.js
+++ b/static/js/triggers-page.js
@@ -132,6 +132,8 @@ const TriggerPage = (function () {
         document.getElementById('outputEmailTo').value = cfg.to || '';
         document.getElementById('outputEmailSubject').value = cfg.subject || '';
 
+        document.getElementById('triggerRequireSignature').checked = !!trigger.require_signature;
+
         // Webhook URL
         if (trigger.trigger_type === 'webhook' && trigger.webhook_path) {
             const webhookUrl = window.location.origin + '/triggers/' + triggerId + '/fire';
@@ -203,6 +205,7 @@ const TriggerPage = (function () {
             cron_expression: triggerType === 'cron' ? document.getElementById('triggerCronExpr').value.trim() : null,
             output_type: outputType,
             output_config: outputConfig,
+            require_signature: document.getElementById('triggerRequireSignature').checked,
         };
 
         const btn = document.getElementById('triggerSubmitBtn');
@@ -224,9 +227,7 @@ const TriggerPage = (function () {
             const result = await resp.json();
             if (!resp.ok) throw new Error(result.detail || 'Request failed');
             closeModal();
-            if (result.fire_key) {
-                _showFireKeyBanner(result.fire_key);
-            }
+            _showSecretsBanner(result.fire_key, result.signing_secret);
             _showNotification(formId ? 'Trigger updated' : 'Trigger created');
             loadTriggers();
         } catch (err) {
@@ -300,6 +301,27 @@ const TriggerPage = (function () {
         }
     }
 
+    async function regenerateSigningSecret() {
+        const triggerId = document.getElementById('triggerFormId').value;
+        if (!triggerId) return;
+        if (!confirm('Regenerate the signing secret? Senders using the old secret will start failing immediately.')) return;
+        try {
+            const resp = await fetch(`/dashboard/api/triggers/${triggerId}`, {
+                method: 'PUT',
+                credentials: 'same-origin',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({regenerate_signing_secret: true}),
+            });
+            const result = await resp.json();
+            if (!resp.ok) throw new Error(result.detail || 'Failed');
+            closeModal();
+            _showSecretsBanner(result.fire_key, result.signing_secret);
+            loadTriggers();
+        } catch (err) {
+            _showNotification('Error: ' + err.message, 'error');
+        }
+    }
+
     async function regenerateKey() {
         const triggerId = document.getElementById('triggerFormId').value;
         if (!triggerId) return;
@@ -314,9 +336,7 @@ const TriggerPage = (function () {
             const result = await resp.json();
             if (!resp.ok) throw new Error(result.detail || 'Failed');
             closeModal();
-            if (result.fire_key) {
-                _showFireKeyBanner(result.fire_key);
-            }
+            _showSecretsBanner(result.fire_key, result.signing_secret);
             loadTriggers();
         } catch (err) {
             _showNotification('Error: ' + err.message, 'error');
@@ -389,6 +409,8 @@ const TriggerPage = (function () {
         });
         document.getElementById('triggerType').value = 'cron';
         document.getElementById('triggerOutputType').value = 'memory_block';
+        const sigChk = document.getElementById('triggerRequireSignature');
+        if (sigChk) sigChk.checked = false;
         const projSel = document.getElementById('triggerProject');
         if (projSel) projSel.value = '';
         // Reset agent dropdown to "select project first" state
@@ -430,11 +452,20 @@ const TriggerPage = (function () {
         return {};
     }
 
-    function _showFireKeyBanner(key) {
+    // Both secrets are shown once and never again, so they share one banner.
+    // Either may be absent: rotating one does not reissue the other.
+    function _showSecretsBanner(fireKey, signingSecret) {
         const banner = document.getElementById('fireKeyBanner');
-        const keyEl = document.getElementById('fireKeyValue');
-        if (!banner || !keyEl) return;
-        keyEl.textContent = key;
+        if (!banner || (!fireKey && !signingSecret)) return;
+
+        const keyRow = document.getElementById('fireKeyRow');
+        if (fireKey) document.getElementById('fireKeyValue').textContent = fireKey;
+        keyRow.classList.toggle('hidden', !fireKey);
+
+        const secretRow = document.getElementById('signingSecretRow');
+        if (signingSecret) document.getElementById('signingSecretValue').textContent = signingSecret;
+        secretRow.classList.toggle('hidden', !signingSecret);
+
         banner.classList.remove('hidden');
         // Auto-hide after 60 seconds
         setTimeout(() => banner.classList.add('hidden'), 60000);
@@ -513,5 +544,6 @@ const TriggerPage = (function () {
         toggleTrigger,
         testFire,
         regenerateKey,
+        regenerateSigningSecret,
     };
 })();

--- a/templates/dashboard/modals/trigger_modal.html
+++ b/templates/dashboard/modals/trigger_modal.html
@@ -94,6 +94,27 @@
                         </button>
                         <span class="text-xs text-gray-400">New key is shown once after regeneration</span>
                     </div>
+                    <div class="pt-2 border-t border-gray-200 dark:border-gray-700 space-y-2">
+                        <label class="flex items-start gap-2 cursor-pointer">
+                            <input type="checkbox" id="triggerRequireSignature"
+                                class="mt-0.5 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500">
+                            <span class="text-xs text-gray-700 dark:text-gray-300">
+                                Require signed requests
+                                <span class="block text-gray-500 dark:text-gray-400">
+                                    HMAC-SHA256 of the raw body in <code class="bg-gray-100 dark:bg-gray-700 px-1 rounded">X-Hub-Signature-256</code>
+                                    or <code class="bg-gray-100 dark:bg-gray-700 px-1 rounded">X-MATE-Signature</code>.
+                                    The fire key alone is then rejected — the body reaches the agent's prompt, so it has to be signed.
+                                </span>
+                            </span>
+                        </label>
+                        <div class="flex items-center gap-2">
+                            <button type="button" id="regenerateSigningSecretBtn" onclick="TriggerPage.regenerateSigningSecret()"
+                                class="px-2 py-1 text-xs bg-yellow-100 dark:bg-yellow-900 text-yellow-800 dark:text-yellow-200 rounded hover:bg-yellow-200 dark:hover:bg-yellow-800">
+                                <i class="fas fa-sync-alt mr-1"></i>Regenerate Signing Secret
+                            </button>
+                            <span class="text-xs text-gray-400">New secret is shown once after regeneration</span>
+                        </div>
+                    </div>
                 </div>
 
                 <!-- Stub warning -->

--- a/templates/dashboard/triggers.html
+++ b/templates/dashboard/triggers.html
@@ -97,15 +97,22 @@
 
 </div>
 
-<!-- Fire Key Banner (shown once after creating a webhook trigger) -->
+<!-- Secrets Banner (shown once after creating or rotating a webhook trigger's secrets) -->
 <div id="fireKeyBanner" class="hidden fixed bottom-4 left-1/2 -translate-x-1/2 z-[100] w-full max-w-lg">
     <div class="bg-yellow-50 dark:bg-yellow-900 border border-yellow-300 dark:border-yellow-600 rounded-lg px-4 py-3 shadow-lg">
         <div class="flex items-start gap-3">
             <i class="fas fa-key text-yellow-600 dark:text-yellow-300 mt-0.5"></i>
             <div class="flex-1">
-                <p class="text-xs font-semibold text-yellow-800 dark:text-yellow-200">Save your trigger fire key — it won't be shown again</p>
-                <code id="fireKeyValue" class="text-xs font-mono text-yellow-900 dark:text-yellow-100 break-all block mt-1"></code>
-                <p class="text-xs text-yellow-700 dark:text-yellow-300 mt-1">Use this key with the <code>X-MATE-Trigger-Key</code> header or <code>?key=</code> query param to fire the webhook.</p>
+                <div id="fireKeyRow">
+                    <p class="text-xs font-semibold text-yellow-800 dark:text-yellow-200">Save your trigger fire key — it won't be shown again</p>
+                    <code id="fireKeyValue" class="text-xs font-mono text-yellow-900 dark:text-yellow-100 break-all block mt-1"></code>
+                    <p class="text-xs text-yellow-700 dark:text-yellow-300 mt-1">Use this key with the <code>X-MATE-Trigger-Key</code> header to fire the webhook.</p>
+                </div>
+                <div id="signingSecretRow" class="hidden mt-2 pt-2 border-t border-yellow-200 dark:border-yellow-700">
+                    <p class="text-xs font-semibold text-yellow-800 dark:text-yellow-200">Signing secret — also shown only once</p>
+                    <code id="signingSecretValue" class="text-xs font-mono text-yellow-900 dark:text-yellow-100 break-all block mt-1"></code>
+                    <p class="text-xs text-yellow-700 dark:text-yellow-300 mt-1">Paste into your sender's webhook secret field. Used only when <em>Require signed requests</em> is on.</p>
+                </div>
             </div>
             <button onclick="document.getElementById('fireKeyBanner').classList.add('hidden')" class="text-yellow-600 dark:text-yellow-300 hover:text-yellow-900">
                 <i class="fas fa-times"></i>


### PR DESCRIPTION
Closes #83

## Problem

`POST /triggers/{id}/fire` authenticates with a shared fire key. This mattered less when the body was discarded. Since #75 the body is interpolated into the agent's prompt through `{{ payload }}`, so **whoever can present the fire key now controls text that goes straight into an LLM prompt** — on an endpoint designed to be called by third parties.

A bearer secret cannot prove who composed a body. Anyone who has ever seen the key — a proxy log, a CI variable, a screenshot of the one-time banner — can forge any payload. And `?key=` puts the secret in the URL, where it lands in access logs, proxy logs and browser history.

## Change

Optional per-trigger signature verification, **off by default** so existing callers keep working.

**Schema** (`V029__trigger_signatures.sql`, all three databases): `agent_triggers` gains `signing_secret` and `require_signature`. A webhook trigger mints a signing secret alongside its fire key, shown once in the same dashboard banner. The secret is stored in the clear — verifying a signature means recomputing it, so a hash could not do — and `to_dict()` never returns it, only `has_signing_secret` and `require_signature`.

**Verification** (`TriggerRunner.verify_signature`): HMAC-SHA256 over the raw body, accepting both `sha256=<hex>` in `X-Hub-Signature-256` (GitHub/GitLab) and a bare hex digest in `X-MATE-Signature`. Mirrors the existing Slack verifier at `server/slack_routes.py:93` — `hmac.compare_digest`, minus the timestamp window.

**Fire endpoint**: reads the raw body *before* anything parses it (re-serialising parsed JSON would not reproduce the signed bytes), then checks the signature after fire-key auth. When required, a missing signature is **401** and a wrong one is **401** — a valid fire key on its own is refused. The existing 403 for a bad fire key is unchanged.

**UI**: a *Require signed requests* checkbox and a *Regenerate Signing Secret* button in the webhook section of the trigger modal; the one-time banner now carries both secrets, showing whichever was issued.

**Docs**: new "Verifying signatures" section in `documents/TRIGGERS.md` beside the payload section, with an `openssl dgst -hmac` example and GitHub/GitLab setup. `?key=` is marked deprecated there and now logs a warning when used — it still works.

Deliberately out of scope, per the issue: replay protection (timestamp/nonce windows) and per-sender key rotation.

## Tests

New `shared/test/test_trigger_signature.py` (22 tests): helper-level checks on both header shapes, wrong body, wrong secret, empty body, and that `hmac.compare_digest` is what compares; endpoint-level checks that a correct signature passes, a wrong or absent one is 401, **a valid fire key without a signature is 401**, verification runs over raw bytes before parsing, a digest over re-serialised JSON does not pass, and that a trigger with verification off behaves exactly as before; plus that `to_dict()` never leaks the secret.

One fixture line in `test_trigger_payload.py` gained `require_signature=False` — a bare `MagicMock` returns a truthy attribute for the new field.

Full suite: 747 tests, all passing.

Verified end-to-end against a running server, on a real trigger created through the API:

| | |
|---|---|
| fire key + correct `X-Hub-Signature-256` | 200 |
| fire key + correct `X-MATE-Signature` | 200 |
| valid fire key, no signature | **401** |
| valid fire key, wrong signature | **401** |
| wrong fire key, correct signature | 403 |
| verification off, unsigned | 200 (unchanged) |
| `?key=` | 200 + deprecation warning logged |

Migration applies cleanly; both columns confirmed present on the SQLite schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)