### PR TITLE
fix: two long-standing papercuts in the migration CLI and agent import

### DIFF
--- a/shared/migrate.py
+++ b/shared/migrate.py
@@ -20,7 +20,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 # Load environment variables
 load_dotenv()
 
-from .utils.migration_system import MigrationSystem
+from shared.utils.migration_system import MigrationSystem
 
 
 def main():

--- a/shared/test/test_import_error_message.py
+++ b/shared/test/test_import_error_message.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""
+Tests that /dashboard/api/agents/import reports the real reason it failed.
+
+The handler raised its own HTTPException inside a `try` whose `except Exception`
+then swallowed and rewrapped it, so every import failure reached the dashboard
+as "Invalid JSON data: 400: <real reason>" — naming the wrong cause for a body
+that parsed perfectly well. Seventeen other handlers in the same file already
+re-raise HTTPException first; this one was the outlier.
+"""
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class TestImportAgentsErrorMessage(unittest.TestCase):
+
+    def setUp(self):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from shared.utils.dashboard.dashboard_server import DashboardServer
+
+        with patch("shared.utils.database_client.get_database_client",
+                   return_value=MagicMock()):
+            project_root = Path(os.path.dirname(os.path.dirname(
+                os.path.dirname(os.path.abspath(__file__)))))
+            app = FastAPI()
+            self.server = DashboardServer(app, project_root)
+
+        app.dependency_overrides[self.server._get_auth_user_dependency] = lambda: "alice"
+        self.client = TestClient(app)
+
+    def test_a_rejected_import_reports_its_own_reason(self):
+        self.server._import_agent_configs = MagicMock(
+            return_value={"error": "Invalid import format: missing 'agents' array"})
+
+        resp = self.client.post("/dashboard/api/agents/import", json={"nope": []})
+
+        self.assertEqual(resp.status_code, 400)
+        detail = resp.json()["detail"]
+        self.assertEqual(detail, "Invalid import format: missing 'agents' array")
+        # The old rewrap blamed the request body for a failure that had nothing
+        # to do with parsing it.
+        self.assertNotIn("Invalid JSON data", detail)
+
+    def test_a_genuinely_unparseable_body_still_says_so(self):
+        # The except Exception branch still has a job — this is what it is for.
+        resp = self.client.post(
+            "/dashboard/api/agents/import",
+            content=b"{not json",
+            headers={"Content-Type": "application/json"},
+        )
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("Invalid JSON data", resp.json()["detail"])
+
+    def test_a_successful_import_is_unaffected(self):
+        self.server._import_agent_configs = MagicMock(
+            return_value={"success": True, "imported_count": 2, "skipped_count": 0, "errors": []})
+        resp = self.client.post("/dashboard/api/agents/import", json={"agents": []})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["imported_count"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/shared/test/test_migrate_cli.py
+++ b/shared/test/test_migrate_cli.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""
+Tests that the documented migration CLI actually runs.
+
+`shared/migrate.py` imported its dependency relatively (`from .utils...`) while
+being invoked as a script, so `python shared/migrate.py run` — the form
+documented in CLAUDE.md, README.md and CONTRIBUTING.md — died on ImportError
+before reaching any command. The `sys.path.append(parent)` already at the top of
+the file shows script invocation was the intent all along.
+
+Invoked with no arguments the CLI prints usage and exits before constructing
+MigrationSystem, so these tests never touch a database.
+"""
+
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class TestMigrateCLIIsRunnable(unittest.TestCase):
+
+    def _run(self, args):
+        return subprocess.run(
+            [sys.executable] + args,
+            cwd=REPO_ROOT, capture_output=True, text=True, timeout=60,
+        )
+
+    def test_documented_script_invocation_reaches_the_cli(self):
+        # The form in CLAUDE.md / README.md / CONTRIBUTING.md.
+        result = self._run(["shared/migrate.py"])
+        self.assertNotIn("ImportError", result.stderr)
+        self.assertNotIn("attempted relative import", result.stderr)
+        self.assertIn("Usage: python migrate.py", result.stdout)
+
+    def test_module_invocation_still_works(self):
+        # The workaround people reach for; it must not regress.
+        result = self._run(["-m", "shared.migrate"])
+        self.assertNotIn("ImportError", result.stderr)
+        self.assertIn("Usage: python migrate.py", result.stdout)
+
+    def test_the_commands_the_docs_promise_are_all_recognised(self):
+        usage = self._run(["shared/migrate.py"]).stdout
+        for command in ("run", "status", "create", "rollback"):
+            self.assertIn(command, usage)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/shared/utils/dashboard/dashboard_server.py
+++ b/shared/utils/dashboard/dashboard_server.py
@@ -4304,6 +4304,8 @@ class DashboardServer:
                     raise HTTPException(status_code=400, detail=result["error"])
                 
                 return result
+            except HTTPException:
+                raise
             except Exception as e:
                 raise HTTPException(status_code=400, detail=f"Invalid JSON data: {str(e)}")
 


### PR DESCRIPTION
Two one-line fixes, both surfaced while working on #79/#82/#83. Neither is a regression — both have been there since the code was written.

## 1. `python shared/migrate.py` has never worked

`shared/migrate.py` imports its dependency relatively (`from .utils.migration_system import ...`) while being invoked as a script, so every command dies on `ImportError: attempted relative import with no known parent package` before doing anything.

That form is documented in three places — [CLAUDE.md:46-49](CLAUDE.md#L46-L49), [README.md:256-259](README.md#L256-L259), [CONTRIBUTING.md:101](CONTRIBUTING.md#L101) — and the `sys.path.append(parent)` already at the top of the file (line 18) shows script invocation was the intent all along. So the import is what is wrong, not the docs.

An absolute import makes **both** invocation styles work:

```
python shared/migrate.py status   # documented form — was broken
python -m shared.migrate status   # the workaround — still works
```

## 2. `agents/import` blamed the wrong thing for its failures

The handler raised its own `HTTPException` inside a `try` whose `except Exception` then swallowed and rewrapped it. Every import failure reached the dashboard as:

```
Invalid JSON data: 400: Invalid import format: missing 'agents' array
```

— naming the request body as the cause of a failure that had nothing to do with parsing it. The status code stayed 400 by coincidence; the message did not.

Seventeen other handlers in the same file already re-raise `HTTPException` first. This one was the outlier. The `except Exception` branch keeps its real job: a genuinely unparseable body still reports "Invalid JSON data".

## Tests

- `shared/test/test_migrate_cli.py` (3 tests) — drives the CLI as a subprocess in both invocation styles. Invoked with no arguments it prints usage and exits before constructing `MigrationSystem`, so the tests never touch a database.
- `shared/test/test_import_error_message.py` (3 tests) — a rejected import reports its own reason; an unparseable body still says so; a successful import is unaffected.

Verified the tests fail against the unpatched code (3 of 6 fail). Full suite: 731 tests, all passing.

Merges cleanly with #85, which touches the same handler — checked; the combined result keeps both the audit call and the re-raise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)