### PR TITLE
fix(usage): make the daily usage charts agree with each other

### DIFF
--- a/shared/test/test_usage_daily_series.py
+++ b/shared/test/test_usage_daily_series.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""
+Tests for the daily usage series behind both dashboard charts.
+
+The overview ("Last 7 Days") and the usage analytics page ("Daily Usage Trend")
+plot the same `daily_usage` field over different windows, and appeared to
+disagree about the same database. Three defects were responsible:
+
+1. The window was built with naive `datetime.now()` while rows are stored in
+   UTC, so on any non-UTC host the range silently shifted by the offset.
+2. `start_date` was a mid-day timestamp, so the oldest bucket was a partial day
+   and always rendered as a dip at the left edge — a trend that was not there.
+3. Days with no traffic were omitted. Charts space points evenly, so gaps
+   collapsed and the x-axis stopped being a timeline. Two windows compress
+   their gaps differently, which is what made the charts disagree.
+"""
+
+import os
+import sys
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from shared.utils.models import Base, TokenUsageLog
+
+
+class TestDailyUsageSeries(unittest.TestCase):
+
+    def setUp(self):
+        self.engine = create_engine(
+            "sqlite:///:memory:",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(self.engine)
+        self.Session = sessionmaker(bind=self.engine)
+
+        self.db_client = MagicMock()
+        self.db_client.get_session.side_effect = lambda: self.Session()
+        self.patcher = patch("shared.utils.database_client.get_database_client",
+                             return_value=self.db_client)
+        self.patcher.start()
+
+        from fastapi import FastAPI
+        from shared.utils.dashboard.dashboard_server import DashboardServer
+
+        project_root = Path(os.path.dirname(os.path.dirname(
+            os.path.dirname(os.path.abspath(__file__)))))
+        self.server = DashboardServer(FastAPI(), project_root)
+        self.server.db_client = self.db_client
+        self.now = datetime.now(timezone.utc)
+
+    def tearDown(self):
+        self.patcher.stop()
+        self.engine.dispose()
+
+    def _seed(self, entries):
+        """entries: iterable of (days_ago, count)."""
+        session = self.Session()
+        for days_ago, count in entries:
+            for i in range(count):
+                session.add(TokenUsageLog(
+                    request_id=f"r{days_ago}-{i}", agent_name="a1", status="SUCCESS",
+                    prompt_tokens=100, response_tokens=50,
+                    timestamp=self.now - timedelta(days=days_ago, minutes=i)))
+        session.commit()
+        session.close()
+
+    def test_series_has_one_point_per_day_in_the_window(self):
+        self._seed([(25, 4), (18, 9), (2, 6)])
+        series = self.server._get_usage_stats(30)["daily_usage"]
+        self.assertEqual(len(series), 30)
+
+    def test_quiet_days_appear_as_zero_not_as_gaps(self):
+        self._seed([(5, 3)])
+        series = self.server._get_usage_stats(7)["daily_usage"]
+        self.assertEqual(len(series), 7)
+        self.assertEqual(sum(1 for d in series if d["requests"] == 0), 6)
+        self.assertEqual([d["requests"] for d in series if d["requests"]], [3])
+
+    def test_dates_are_consecutive_and_end_today(self):
+        # The x-axis must be a real timeline, not a list of days that had traffic.
+        self._seed([(3, 2)])
+        series = self.server._get_usage_stats(7)["daily_usage"]
+        dates = [datetime.fromisoformat(d["date"]).date() for d in series]
+        self.assertEqual(dates, sorted(dates))
+        for earlier, later in zip(dates, dates[1:]):
+            self.assertEqual((later - earlier).days, 1)
+        self.assertEqual(dates[-1], self.now.date())
+
+    def test_the_oldest_bucket_is_a_whole_day(self):
+        # Seed the full first day. A mid-day start would only count part of it.
+        oldest = 6
+        self._seed([(oldest, 24)])
+        series = self.server._get_usage_stats(7)["daily_usage"]
+        self.assertEqual(series[0]["requests"], 24)
+
+    def test_totals_do_not_move_with_the_host_timezone(self):
+        # Rows are UTC; a naive local window shifted the range by the host offset.
+        self._seed([(d, 5) for d in range(7)])
+
+        def totals_under(tz):
+            with patch.dict(os.environ, {"TZ": tz}):
+                if hasattr(os, "tzset"):
+                    os.tzset()
+                return self.server._get_usage_stats(7)["total_requests"]
+
+        try:
+            utc = totals_under("UTC")
+            plus_two = totals_under("Europe/Belgrade")
+            minus_eight = totals_under("America/Los_Angeles")
+        finally:
+            if hasattr(os, "tzset"):
+                os.tzset()
+
+        self.assertEqual(utc, plus_two)
+        self.assertEqual(utc, minus_eight)
+
+    def test_daily_requests_sum_to_the_headline_total(self):
+        # The chart and the number above it must not tell different stories.
+        self._seed([(1, 4), (3, 7)])
+        stats = self.server._get_usage_stats(7)
+        self.assertEqual(sum(d["requests"] for d in stats["daily_usage"]),
+                         stats["total_requests"])
+
+    def test_failures_stay_out_of_the_series(self):
+        self._seed([(1, 3)])
+        session = self.Session()
+        session.add(TokenUsageLog(request_id="denied", agent_name="a1",
+                                  status="ACCESS_DENIED", prompt_tokens=0,
+                                  response_tokens=0,
+                                  timestamp=self.now - timedelta(days=1)))
+        session.commit()
+        session.close()
+        series = self.server._get_usage_stats(7)["daily_usage"]
+        self.assertEqual(sum(d["requests"] for d in series), 3)
+
+    def test_empty_database_still_yields_a_full_series(self):
+        series = self.server._get_usage_stats(7)["daily_usage"]
+        self.assertEqual(len(series), 7)
+        self.assertTrue(all(d["requests"] == 0 and d["tokens"] == 0 for d in series))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/shared/test/test_usage_daily_series.py
+++ b/shared/test/test_usage_daily_series.py
@@ -17,10 +17,12 @@ disagree about the same database. Three defects were responsible:
 
 import os
 import sys
+import time
 import unittest
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+from zoneinfo import ZoneInfo
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -104,21 +106,42 @@ class TestDailyUsageSeries(unittest.TestCase):
 
     def test_totals_do_not_move_with_the_host_timezone(self):
         # Rows are UTC; a naive local window shifted the range by the host offset.
-        self._seed([(d, 5) for d in range(7)])
+        # The data has to be dense right up to the window edge for the shift to
+        # show: sparse rows sitting far from the boundary survive a two-hour
+        # slide unchanged, and the test would pass against the broken code.
+        session = self.Session()
+        for hour in range(9 * 24):
+            session.add(TokenUsageLog(
+                request_id=f"h{hour}", agent_name="a1", status="SUCCESS",
+                prompt_tokens=10, response_tokens=5,
+                timestamp=self.now - timedelta(hours=hour)))
+        session.commit()
+        session.close()
+
+        if not hasattr(time, "tzset"):
+            self.skipTest("tzset is unavailable on this platform")
 
         def totals_under(tz):
-            with patch.dict(os.environ, {"TZ": tz}):
-                if hasattr(os, "tzset"):
-                    os.tzset()
-                return self.server._get_usage_stats(7)["total_requests"]
+            # os.environ must be assigned directly: patching it through
+            # mock.patch.dict does not reach putenv, so tzset() reads the old
+            # zone and the test silently stops exercising anything.
+            os.environ["TZ"] = tz
+            time.tzset()
+            self.assertEqual(datetime.now().hour, datetime.now(ZoneInfo(tz)).hour,
+                             f"TZ={tz} did not take effect; the check below is vacuous")
+            return self.server._get_usage_stats(7)["total_requests"]
 
+        original_tz = os.environ.get("TZ")
         try:
             utc = totals_under("UTC")
             plus_two = totals_under("Europe/Belgrade")
             minus_eight = totals_under("America/Los_Angeles")
         finally:
-            if hasattr(os, "tzset"):
-                os.tzset()
+            if original_tz is None:
+                os.environ.pop("TZ", None)
+            else:
+                os.environ["TZ"] = original_tz
+            time.tzset()
 
         self.assertEqual(utc, plus_two)
         self.assertEqual(utc, minus_eight)

--- a/shared/utils/dashboard/dashboard_server.py
+++ b/shared/utils/dashboard/dashboard_server.py
@@ -242,6 +242,31 @@ class DashboardServer:
 
         return last_text.strip()
 
+    @staticmethod
+    def _fill_daily_gaps(rows: List[Any], start_date: Any, days: int) -> List[Dict[str, Any]]:
+        """Expand grouped daily rows into one entry per day, zeroes included.
+
+        GROUP BY date only returns days that have traffic. Charts plot points at
+        even spacing, so omitting quiet days makes the x-axis stop being a
+        timeline: a month with three busy days is drawn as three adjacent points
+        and reads as continuous activity. Two charts over different windows then
+        compress their gaps differently and appear to disagree about the same data.
+        """
+        from datetime import timedelta
+
+        # func.date() gives a str on SQLite and a date on PostgreSQL/MySQL.
+        by_date = {str(row.date): row for row in rows}
+        series = []
+        for offset in range(days):
+            day = (start_date + timedelta(days=offset)).date().isoformat()
+            row = by_date.get(day)
+            series.append({
+                'date': day,
+                'requests': row.requests if row else 0,
+                'tokens': (row.total_tokens or 0) if row else 0,
+            })
+        return series
+
     def _get_usage_stats(self, days: int = 7,
                          origins: Optional[tuple] = None) -> Dict[str, Any]:
         """Get usage statistics from database.
@@ -267,10 +292,21 @@ class DashboardServer:
         
         try:
             from sqlalchemy import func
-            from datetime import datetime, timedelta
-            
-            end_date = datetime.now()
-            start_date = end_date - timedelta(days=days)
+            from datetime import datetime, timedelta, timezone
+
+            # Rows are written with datetime.now(timezone.utc) and stored naive, so the
+            # window has to be computed in UTC as well. Naive local time silently
+            # shifts it by the host's offset — on a UTC+2 server a 7-day window drops
+            # the oldest two hours of traffic.
+            now_utc = datetime.now(timezone.utc).replace(tzinfo=None)
+            end_date = now_utc
+            # Snap the start to midnight so the oldest bucket is a whole day. With a
+            # mid-day start the first day was always a partial one, which rendered as
+            # a dip at the left edge of every chart and read as a trend that was not
+            # there. Anchoring at now - (days - 1) keeps exactly `days` buckets,
+            # the last being today so far.
+            start_date = (now_utc - timedelta(days=days - 1)).replace(
+                hour=0, minute=0, second=0, microsecond=0)
 
             # These panels report successful LLM traffic and sit next to token sums, so
             # they must exclude the zero-token rows written for failures (status='ERROR')
@@ -341,7 +377,7 @@ class DashboardServer:
                 'unique_users': stats.unique_users or 0,
                 'unique_agents': stats.unique_agents or 0,
                 'top_agents': [self._agent_row(agent, perf, end_date) for agent in top_agents],
-                'daily_usage': [{'date': str(day.date), 'requests': day.requests, 'tokens': day.total_tokens or 0} for day in daily_usage],
+                'daily_usage': self._fill_daily_gaps(daily_usage, start_date, days),
                 'hourly_usage': hourly_data,
                 'database_info': self._get_database_info()
             }

--- a/templates/dashboard/usage.html
+++ b/templates/dashboard/usage.html
@@ -467,20 +467,33 @@
                     tension: 0.4,
                     fill: true
                 }, {
-                    label: 'Tokens (÷100)',
-                    data: dailyData.map(d => Math.round((d.tokens || 0) / 100)),
+                    label: 'Tokens',
+                    data: dailyData.map(d => d.tokens || 0),
                     borderColor: 'rgb(16, 185, 129)',
                     backgroundColor: 'rgba(16, 185, 129, 0.1)',
                     tension: 0.4,
-                    fill: true
+                    fill: true,
+                    yAxisID: 'y1'
                 }]
             },
             options: {
                 responsive: true,
                 maintainAspectRatio: false,
                 scales: {
+                    // Tokens outrun requests by three orders of magnitude, so a shared
+                    // axis flattened the request line onto zero and made a busy week
+                    // look idle. Scaling tokens by 100 only moved the problem. Each
+                    // series now gets its own axis, matching the overview chart.
                     y: {
-                        beginAtZero: true
+                        beginAtZero: true,
+                        position: 'left',
+                        title: { display: true, text: 'Requests' }
+                    },
+                    y1: {
+                        beginAtZero: true,
+                        position: 'right',
+                        title: { display: true, text: 'Tokens' },
+                        grid: { drawOnChartArea: false }
                     }
                 },
                 plugins: {


### PR DESCRIPTION
Reported from the dashboard: the overview chart and the usage analytics chart look like they describe different systems.

They plot the **same** `daily_usage` field over different windows, so they should never disagree. Three defects in the query and one presentation choice explain why they did.

## 1. The window was built in local time, the rows are stored in UTC

Rows are written with `datetime.now(timezone.utc)` and stored naive. The window used naive `datetime.now()`. On any host not on UTC the range silently shifted by the offset.

Measured on identical seeded data — one row per hour for nine days:

| Host timezone | Rows in a 7-day window |
|---|---|
| `UTC` | 168 |
| `Europe/Belgrade` | **166** |

Two hours of traffic vanished, invisibly. A UTC-7 host also returns 168, from a window shifted seven hours the other way — the same defect, but invisible to a count. The window is now computed in UTC.

## 2. The oldest bucket was a partial day

`start_date` was `now - N days` — a mid-day timestamp — so the first bucket covered only part of a day and always read low. That drew as a dip at the left edge of every chart and looked like a ramp that was not in the data. The start now snaps to midnight, anchored so the series holds exactly `days` buckets ending with today.

## 3. Quiet days were dropped, so the x-axis was not a timeline

`GROUP BY date` only returns days with traffic, and nothing re-added the rest. Charts space points evenly, so a 30-day window over three busy days drew **three adjacent points** and read as continuous activity.

This is the one that made the two charts disagree: they use different windows, so they compressed their gaps differently. `_fill_daily_gaps` now returns one entry per day, zeroes included.

## 4. The analytics chart put both series on one axis

It plotted requests and tokens together, scaling tokens by 100 to compensate. Tokens still outrun requests by orders of magnitude, so the request line sat flat on zero and a busy week looked idle — which is most of why the analytics chart appeared to contradict the overview. Tokens now get their own axis, matching the overview, and the `÷100` label goes away.

## Verification

776 tests pass, 8 new. Reverting the fix fails **five** of the eight:

| Test | Against the old code |
|---|---|
| `test_series_has_one_point_per_day_in_the_window` | `3 != 30` |
| `test_quiet_days_appear_as_zero_not_as_gaps` | `1 != 7` |
| `test_dates_are_consecutive_and_end_today` | series ends `2026-08-30`, not today |
| `test_empty_database_still_yields_a_full_series` | `0 != 7` |
| `test_totals_do_not_move_with_the_host_timezone` | `168 != 166` |

The second commit exists because the first version of the timezone test **passed against the broken code** — it guarded nothing. Its data was too sparse to notice a two-hour slide, and `mock.patch.dict` on `os.environ` does not reach `putenv`, so the `tzset()` after it re-read the old zone. It now assigns the environment directly, restores it in a `finally`, and asserts the requested zone actually took effect before drawing any conclusion from it. Suite re-run twice to confirm no timezone leaks into other tests.

Live against the running server with a sparse month seeded (traffic on 7 of 29 days), reading the actual rendered HTML of both pages:

```
OVERVIEW points = 7  [08-27:0, 08-28:7, 08-29:0, 08-30:9, 08-31:0, 09-01:14, 09-02:6]
USAGE    points = 30  total = 59  sum of daily = 59
overlap = 7 days   disagreements = 0
```

Each page's daily requests now sum to the total printed above its chart.

## Worth knowing before merging

Fixing the window changes reported figures slightly — the first day is now whole rather than partial, so totals over a given range may tick up. That is the correction, not a regression.

`hourly_usage` still buckets by UTC hour, so the "busiest hour" panel reads in UTC on a non-UTC host. Same root cause, different panel; left alone here rather than widening the change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ToCUNy2SqwvfTq4a6xfSk1