### PR TITLE
feat(mcp): reach external MCP servers over HTTP, and resolve ${VAR} secrets from the environment

### DIFF
--- a/documents/MCP_SERVERS.md
+++ b/documents/MCP_SERVERS.md
@@ -166,6 +166,37 @@ If an entry sets both, `url` wins and the command is ignored.
 This replaces the older workaround of wrapping a remote server in `npx mcp-remote`
 over stdio, which needed Node on the host and a subprocess per server.
 
+### Secrets: `${VAR}` interpolation
+
+Any string value in a server entry may reference the server's environment as
+`${VAR}` — in `headers`, `url`, `command`, `args` or `env`. The value is read from
+the environment when the toolset is built, so credentials stay out of the
+`agents_config` row and out of config exports.
+
+```json
+{
+  "mcpServers": {
+    "tavily": {
+      "url": "https://mcp.tavily.com/mcp",
+      "headers": {"Authorization": "Bearer ${TAVILY_API_KEY}"}
+    }
+  }
+}
+```
+
+Rules:
+
+- Only `${NAME}` is a placeholder. A bare `$NAME` is left alone.
+- **If a referenced variable is unset, the server is skipped** and the agent
+  answers without its tools, with the missing names logged. Sending the request
+  without the credential, or with the literal text `${NAME}` as the credential,
+  are both worse failures.
+- A variable that is set but empty is treated as a real value, not a miss.
+
+Note that interpolation reads the server's environment, so anyone who can edit an
+agent's MCP config can route an environment value to the URL they choose. That is
+the same trust level agent configuration already carries.
+
 ### stdio servers
 
 **Configuration Format:**

--- a/documents/MCP_SERVERS.md
+++ b/documents/MCP_SERVERS.md
@@ -128,7 +128,45 @@ curl -u admin:mate -X POST http://localhost:8000/agents/creative_agent/mcp/tools
 
 ## External MCP Servers
 
-Agents can connect to external MCP servers via the `mcp_servers_config` field in the `agents_config` database table. These are created using stdio connections and exposed as tools to agents (not as HTTP endpoints).
+Agents can connect to external MCP servers via the `mcp_servers_config` field in the `agents_config` database table. The remote server's tools are exposed to the agent as ordinary tools.
+
+Two transports are supported, chosen by what the server entry contains:
+
+| Entry has | Transport | Use for |
+|-----------|-----------|---------|
+| `url` | Streamable HTTP (or SSE) | Remote servers reachable over the network |
+| `command` + `args` | stdio | Servers that run as a local subprocess |
+
+If an entry sets both, `url` wins and the command is ignored.
+
+### HTTP servers
+
+**Configuration Format:**
+```json
+{
+  "mcpServers": {
+    "server_name": {
+      "url": "https://mcp.example.com/mcp",
+      "headers": {"Authorization": "Bearer YOUR_TOKEN"},
+      "transport": "streamable_http",
+      "timeout": 60
+    }
+  }
+}
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `url` | string | required | Server endpoint. Must be `http` or `https`; anything else is refused |
+| `headers` | object | `{}` | Extra request headers, typically `Authorization` |
+| `transport` | string | `streamable_http` | `streamable_http` or `sse` for older servers. `type` is accepted as a synonym |
+| `timeout` | number | 60 | How long a tool call may take, in seconds. Raise it for slow tools |
+| `connect_timeout` | number | 5 | How long to wait for the connection itself |
+
+This replaces the older workaround of wrapping a remote server in `npx mcp-remote`
+over stdio, which needed Node on the host and a subprocess per server.
+
+### stdio servers
 
 **Configuration Format:**
 ```json
@@ -165,7 +203,7 @@ Agents can connect to external MCP servers via the `mcp_servers_config` field in
 }
 ```
 
-External MCP servers are created via `create_mcp_tools_from_config()` function which uses stdio connections (`StdioConnectionParams`) to communicate with remote MCP servers.
+External MCP servers are created via `create_mcp_tools_from_config()`, which dispatches on the server entry: `create_mcp_toolset_http()` for a `url` (`StreamableHTTPConnectionParams` or `SseConnectionParams`) and `create_mcp_toolset_command()` for `command`/`args` (`StdioConnectionParams`).
 
 ---
 

--- a/shared/test/test_mcp_env_interpolation.py
+++ b/shared/test/test_mcp_env_interpolation.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+Tests for ${VAR} interpolation in MCP server config.
+
+The dashboard promised this for years without implementing it, so a token pasted
+as ${AUTH_TOKEN} was sent to the remote server as the literal seven-character
+string. Credentials also should not have to be stored in an agent config row to
+be usable.
+
+An unset variable skips the server. The alternatives are worse in both
+directions: substituting empty sends an unauthenticated request that may
+succeed with reduced scope, and leaving the placeholder sends `${VAR}` as the
+credential.
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from google.adk.tools.mcp_tool.mcp_session_manager import StdioConnectionParams
+
+from shared.utils.tools.mcp_tools import create_mcp_tools_from_config
+
+
+def config(**servers):
+    return {"name": "a1", "mcp_servers_config": {"mcpServers": servers}}
+
+
+def params_of(toolset):
+    return toolset._mcp_session_manager._connection_params
+
+
+class TestEnvInterpolation(unittest.TestCase):
+
+    def test_a_header_secret_is_read_from_the_environment(self):
+        with patch.dict(os.environ, {"AUTH_TOKEN": "s3cret"}):
+            tools = create_mcp_tools_from_config(config(remote={
+                "url": "https://mcp.example.com/mcp",
+                "headers": {"Authorization": "Bearer ${AUTH_TOKEN}"},
+            }))
+        self.assertEqual(params_of(tools[0]).headers,
+                         {"Authorization": "Bearer s3cret"})
+
+    def test_the_placeholder_may_sit_inside_a_url(self):
+        with patch.dict(os.environ, {"MCP_HOST": "mcp.example.com"}):
+            tools = create_mcp_tools_from_config(config(remote={
+                "url": "https://${MCP_HOST}/mcp"}))
+        self.assertEqual(params_of(tools[0]).url, "https://mcp.example.com/mcp")
+
+    def test_several_placeholders_in_one_string(self):
+        with patch.dict(os.environ, {"A": "one", "B": "two"}):
+            tools = create_mcp_tools_from_config(config(remote={
+                "url": "https://example.com/${A}/${B}"}))
+        self.assertEqual(params_of(tools[0]).url, "https://example.com/one/two")
+
+    def test_stdio_args_and_env_are_interpolated_too(self):
+        # The documented Tavily example carries its API key inside args.
+        with patch.dict(os.environ, {"TAVILY_KEY": "tvly-123", "REGION": "eu"}):
+            with patch("shared.utils.tools.mcp_tools.resolve_mcp_command",
+                       return_value="/usr/bin/npx"):
+                tools = create_mcp_tools_from_config(config(local={
+                    "command": "npx",
+                    "args": ["mcp-remote", "https://mcp.tavily.com/?key=${TAVILY_KEY}"],
+                    "env": {"REGION": "${REGION}"},
+                }))
+        params = params_of(tools[0])
+        self.assertIsInstance(params, StdioConnectionParams)
+        self.assertEqual(params.server_params.args[1],
+                         "https://mcp.tavily.com/?key=tvly-123")
+        self.assertEqual(params.server_params.env["REGION"], "eu")
+
+    def test_an_unset_variable_skips_the_server(self):
+        # The bug this replaces sent `${AUTH_TOKEN}` itself as the credential.
+        os.environ.pop("DEFINITELY_NOT_SET", None)
+        tools = create_mcp_tools_from_config(config(remote={
+            "url": "https://mcp.example.com/mcp",
+            "headers": {"Authorization": "Bearer ${DEFINITELY_NOT_SET}"},
+        }))
+        self.assertEqual(tools, [])
+
+    def test_an_unset_variable_skips_only_that_server(self):
+        os.environ.pop("DEFINITELY_NOT_SET", None)
+        tools = create_mcp_tools_from_config(config(
+            broken={"url": "https://a.example.com/mcp",
+                    "headers": {"Authorization": "${DEFINITELY_NOT_SET}"}},
+            fine={"url": "https://b.example.com/mcp"},
+        ))
+        self.assertEqual(len(tools), 1)
+        self.assertEqual(params_of(tools[0]).url, "https://b.example.com/mcp")
+
+    def test_an_empty_variable_is_a_value_not_a_miss(self):
+        # Set-but-empty is a deliberate choice by whoever set it.
+        with patch.dict(os.environ, {"EMPTY_ON_PURPOSE": ""}):
+            tools = create_mcp_tools_from_config(config(remote={
+                "url": "https://mcp.example.com/mcp",
+                "headers": {"X-Key": "${EMPTY_ON_PURPOSE}"},
+            }))
+        self.assertEqual(params_of(tools[0]).headers, {"X-Key": ""})
+
+    def test_config_without_placeholders_is_untouched(self):
+        tools = create_mcp_tools_from_config(config(remote={
+            "url": "https://mcp.example.com/mcp",
+            "headers": {"Authorization": "Bearer literal-token"},
+        }))
+        self.assertEqual(params_of(tools[0]).headers,
+                         {"Authorization": "Bearer literal-token"})
+
+    def test_a_secret_containing_a_quote_survives_a_json_string_field(self):
+        # Interpolation happens after JSON parsing precisely so this cannot
+        # corrupt the surrounding document.
+        with patch.dict(os.environ, {"WEIRD": 'a"b'}):
+            tools = create_mcp_tools_from_config(config(remote={
+                "url": "https://mcp.example.com/mcp",
+                "headers": '{"X-Key": "${WEIRD}"}',
+            }))
+        self.assertEqual(params_of(tools[0]).headers, {"X-Key": 'a"b'})
+
+    def test_a_dollar_without_braces_is_left_alone(self):
+        tools = create_mcp_tools_from_config(config(remote={
+            "url": "https://mcp.example.com/mcp",
+            "headers": {"X-Key": "$HOME and $100"},
+        }))
+        self.assertEqual(params_of(tools[0]).headers, {"X-Key": "$HOME and $100"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/shared/test/test_mcp_http_transport.py
+++ b/shared/test/test_mcp_http_transport.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""
+Tests for reaching external MCP servers over HTTP.
+
+MATE serves its own agents as HTTP MCP servers but the client could only speak
+stdio, so a remote server had to be reached by spawning `npx mcp-remote` as a
+subprocess — a Node dependency on the host and a process per server, to talk to
+a protocol MATE already implements on the other side.
+
+A server config is now HTTP when it carries a `url`, and stdio when it carries
+`command`/`args`. The stdio path has to keep working untouched: it is what every
+existing installation is configured with.
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from google.adk.tools.mcp_tool.mcp_session_manager import (
+    SseConnectionParams,
+    StdioConnectionParams,
+    StreamableHTTPConnectionParams,
+)
+
+from shared.utils.tools.mcp_tools import create_mcp_tools_from_config
+
+
+def config(**servers):
+    return {"name": "a1", "mcp_servers_config": {"mcpServers": servers}}
+
+
+def params_of(toolset):
+    """The connection params the toolset was built with."""
+    return toolset._mcp_session_manager._connection_params
+
+
+class TestHttpTransport(unittest.TestCase):
+
+    def test_a_url_produces_a_streamable_http_toolset(self):
+        tools = create_mcp_tools_from_config(
+            config(remote={"url": "https://mcp.example.com/mcp"}))
+        self.assertEqual(len(tools), 1)
+        params = params_of(tools[0])
+        self.assertIsInstance(params, StreamableHTTPConnectionParams)
+        self.assertEqual(params.url, "https://mcp.example.com/mcp")
+
+    def test_sse_transport_is_selectable_for_older_servers(self):
+        for key in ("transport", "type"):
+            with self.subTest(key=key):
+                tools = create_mcp_tools_from_config(
+                    config(remote={"url": "https://mcp.example.com/sse", key: "sse"}))
+                self.assertIsInstance(params_of(tools[0]), SseConnectionParams)
+
+    def test_headers_reach_the_transport(self):
+        tools = create_mcp_tools_from_config(config(remote={
+            "url": "https://mcp.example.com/mcp",
+            "headers": {"Authorization": "Bearer s3cret"},
+        }))
+        self.assertEqual(params_of(tools[0]).headers,
+                         {"Authorization": "Bearer s3cret"})
+
+    def test_headers_may_arrive_as_a_json_string(self):
+        # Config reaches this function already parsed or still encoded, depending
+        # on whether it came from the database or the dashboard.
+        tools = create_mcp_tools_from_config(config(remote={
+            "url": "https://mcp.example.com/mcp",
+            "headers": '{"Authorization": "Bearer s3cret"}',
+        }))
+        self.assertEqual(params_of(tools[0]).headers,
+                         {"Authorization": "Bearer s3cret"})
+
+    def test_timeout_keeps_the_meaning_it_has_for_stdio(self):
+        # `timeout` is documented as how long a slow tool may take, so it maps to
+        # the read timeout, not to the connect timeout.
+        tools = create_mcp_tools_from_config(config(remote={
+            "url": "https://mcp.example.com/mcp", "timeout": 300}))
+        params = params_of(tools[0])
+        self.assertEqual(params.sse_read_timeout, 300.0)
+        self.assertEqual(params.timeout, 5.0)
+
+    def test_connect_timeout_is_separately_configurable(self):
+        tools = create_mcp_tools_from_config(config(remote={
+            "url": "https://mcp.example.com/mcp", "connect_timeout": 20}))
+        self.assertEqual(params_of(tools[0]).timeout, 20.0)
+
+    def test_a_non_http_url_is_refused(self):
+        for url in ("file:///etc/passwd", "ftp://example.com/x", "not-a-url"):
+            with self.subTest(url=url):
+                self.assertEqual(create_mcp_tools_from_config(config(bad={"url": url})), [])
+
+    def test_url_wins_when_a_config_sets_both(self):
+        tools = create_mcp_tools_from_config(config(both={
+            "url": "https://mcp.example.com/mcp",
+            "command": "npx",
+            "args": ["mcp-remote", "https://mcp.example.com/mcp"],
+        }))
+        self.assertEqual(len(tools), 1)
+        self.assertIsInstance(params_of(tools[0]), StreamableHTTPConnectionParams)
+
+
+class TestStdioStillWorks(unittest.TestCase):
+    """The path every existing installation is already configured with."""
+
+    def test_command_config_still_produces_a_stdio_toolset(self):
+        with patch("shared.utils.tools.mcp_tools.resolve_mcp_command",
+                   return_value="/usr/bin/npx"):
+            tools = create_mcp_tools_from_config(config(local={
+                "command": "npx", "args": ["-y", "some-mcp"], "timeout": 120}))
+        self.assertEqual(len(tools), 1)
+        params = params_of(tools[0])
+        self.assertIsInstance(params, StdioConnectionParams)
+        self.assertEqual(params.timeout, 120.0)
+        self.assertEqual(params.server_params.command, "/usr/bin/npx")
+
+    def test_args_and_env_may_still_arrive_as_json_strings(self):
+        with patch("shared.utils.tools.mcp_tools.resolve_mcp_command",
+                   return_value="/usr/bin/npx"):
+            tools = create_mcp_tools_from_config(config(local={
+                "command": "npx", "args": '["-y", "some-mcp"]', "env": '{"K": "V"}'}))
+        params = params_of(tools[0])
+        self.assertEqual(params.server_params.args, ["-y", "some-mcp"])
+        self.assertEqual(params.server_params.env["K"], "V")
+
+    def test_invalid_args_json_skips_only_that_server(self):
+        with patch("shared.utils.tools.mcp_tools.resolve_mcp_command",
+                   return_value="/usr/bin/npx"):
+            tools = create_mcp_tools_from_config(config(
+                broken={"command": "npx", "args": "{not json"},
+                fine={"command": "npx", "args": ["-y", "ok"]},
+            ))
+        self.assertEqual(len(tools), 1)
+
+    def test_a_server_with_neither_url_nor_command_is_skipped(self):
+        self.assertEqual(create_mcp_tools_from_config(config(empty={"timeout": 30})), [])
+
+    def test_http_and_stdio_servers_coexist_in_one_config(self):
+        with patch("shared.utils.tools.mcp_tools.resolve_mcp_command",
+                   return_value="/usr/bin/npx"):
+            tools = create_mcp_tools_from_config(config(
+                remote={"url": "https://mcp.example.com/mcp"},
+                local={"command": "npx", "args": ["-y", "some-mcp"]},
+            ))
+        self.assertEqual(len(tools), 2)
+        kinds = {type(params_of(t)) for t in tools}
+        self.assertEqual(kinds, {StreamableHTTPConnectionParams, StdioConnectionParams})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/shared/utils/tools/mcp_tools.py
+++ b/shared/utils/tools/mcp_tools.py
@@ -5,6 +5,7 @@ MCP (Model Context Protocol) tools creation and management.
 import logging
 import json
 import os
+import re
 import shutil
 from typing import Dict, List, Any, Optional
 from urllib.parse import urlparse
@@ -68,10 +69,10 @@ def create_mcp_toolset_command(
             for slow tools like tavily_research (e.g. 300).
 
     Returns:
-        MCPToolset instance or None if creation fails
+        McpToolset instance or None if creation fails
     """
     try:
-        from google.adk.tools.mcp_tool.mcp_toolset import MCPToolset, StdioConnectionParams, StdioServerParameters
+        from google.adk.tools.mcp_tool.mcp_toolset import McpToolset, StdioConnectionParams, StdioServerParameters
 
         # Resolve the command to a full absolute path before spawning.
         # This avoids a cryptic FileNotFoundError at subprocess-creation time and
@@ -89,7 +90,7 @@ def create_mcp_toolset_command(
         env_vars = os.environ.copy()
         env_vars.update(env)
 
-        mcp_toolset = MCPToolset(
+        mcp_toolset = McpToolset(
             connection_params=StdioConnectionParams(
                 timeout=float(timeout),
                 server_params=StdioServerParameters(
@@ -140,10 +141,10 @@ def create_mcp_toolset_http(
         transport: 'streamable_http' (default) or 'sse' for older servers.
 
     Returns:
-        MCPToolset instance or None if creation fails
+        McpToolset instance or None if creation fails
     """
     try:
-        from google.adk.tools.mcp_tool.mcp_toolset import MCPToolset
+        from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
         from google.adk.tools.mcp_tool.mcp_session_manager import (
             SseConnectionParams,
             StreamableHTTPConnectionParams,
@@ -162,7 +163,7 @@ def create_mcp_toolset_http(
             return None
 
         params_cls = SseConnectionParams if transport == "sse" else StreamableHTTPConnectionParams
-        mcp_toolset = MCPToolset(
+        mcp_toolset = McpToolset(
             connection_params=params_cls(
                 url=url,
                 headers=headers or None,
@@ -182,6 +183,50 @@ def create_mcp_toolset_http(
     except Exception as e:
         logger.error(f"Failed to create HTTP MCP toolset for agent {agent_name}: {e}")
         return None
+
+
+# Secrets do not belong in agent config rows, so string values in an MCP server
+# entry may reference the server environment as ${VAR}.
+_ENV_PLACEHOLDER = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+
+
+def _resolve_env(obj: Any, server_name: str, agent_name: str) -> Optional[Any]:
+    """
+    Replace ${VAR} references with values from the environment, recursing through
+    lists and dicts.
+
+    Returns None if any referenced variable is unset, having logged which ones.
+    Skipping the server is the safe failure: substituting an empty string would
+    send an unauthenticated request, and leaving the placeholder would send the
+    literal text `${VAR}` as the credential.
+    """
+    missing = set()
+
+    def walk(value: Any) -> Any:
+        if isinstance(value, str):
+            def substitute(match):
+                name = match.group(1)
+                resolved = os.environ.get(name)
+                if resolved is None:
+                    missing.add(name)
+                    return match.group(0)
+                return resolved
+            return _ENV_PLACEHOLDER.sub(substitute, value)
+        if isinstance(value, list):
+            return [walk(item) for item in value]
+        if isinstance(value, dict):
+            return {key: walk(item) for key, item in value.items()}
+        return value
+
+    resolved = walk(obj)
+    if missing:
+        logger.error(
+            f"Skipping MCP server '{server_name}' for agent '{agent_name}': "
+            f"{', '.join(sorted(missing))} not set in the environment. "
+            f"The agent will respond without this MCP tool."
+        )
+        return None
+    return resolved
 
 
 def _parse_json_field(value: Any, field: str, server_name: str, agent_name: str) -> Optional[Any]:
@@ -248,9 +293,15 @@ def create_mcp_tools_from_config(config: Dict[str, Any]) -> List[Any]:
                                 f"MCP server '{server_name}' in agent '{agent_name}' sets both "
                                 f"url and command; using url and ignoring command"
                             )
+                        # Interpolate after parsing, so a secret containing a quote
+                        # cannot corrupt a field that arrived as a JSON string.
+                        resolved = _resolve_env(
+                            {'url': url, 'headers': headers}, server_name, agent_name)
+                        if resolved is None:
+                            continue
                         mcp_toolset = create_mcp_toolset_http(
-                            url,
-                            headers,
+                            resolved['url'],
+                            resolved['headers'],
                             f"{agent_name}_{server_name}",
                             timeout=timeout,
                             connect_timeout=server_config.get('connect_timeout', 5.0),
@@ -274,8 +325,14 @@ def create_mcp_tools_from_config(config: Dict[str, Any]) -> List[Any]:
                             )
                             continue
 
+                        resolved = _resolve_env(
+                            {'command': command, 'args': args, 'env': env},
+                            server_name, agent_name)
+                        if resolved is None:
+                            continue
                         mcp_toolset = create_mcp_toolset_command(
-                            command, args, env, f"{agent_name}_{server_name}", timeout=timeout
+                            resolved['command'], resolved['args'], resolved['env'],
+                            f"{agent_name}_{server_name}", timeout=timeout
                         )
 
                     if mcp_toolset:

--- a/shared/utils/tools/mcp_tools.py
+++ b/shared/utils/tools/mcp_tools.py
@@ -7,6 +7,7 @@ import json
 import os
 import shutil
 from typing import Dict, List, Any, Optional
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
@@ -113,6 +114,93 @@ def create_mcp_toolset_command(
         return None
 
 
+def create_mcp_toolset_http(
+    url: str,
+    headers: Dict[str, str],
+    agent_name: str = "unknown",
+    timeout: int = 60,
+    connect_timeout: float = 5.0,
+    transport: str = "streamable_http",
+) -> Any:
+    """
+    Create an MCP toolset that talks to a remote server over HTTP.
+
+    MATE already serves its own agents as HTTP MCP servers, but the client could
+    only speak stdio, so remote servers had to be reached by spawning
+    `npx mcp-remote` as a subprocess. This removes that hop, and the Node
+    dependency along with it.
+
+    Args:
+        url: Server endpoint, http or https.
+        headers: Extra request headers, typically Authorization.
+        agent_name: Name of the agent (for logging).
+        timeout: How long a tool call may take before giving up, in seconds.
+            Matches the meaning `timeout` already has for stdio servers.
+        connect_timeout: How long to wait for the connection itself.
+        transport: 'streamable_http' (default) or 'sse' for older servers.
+
+    Returns:
+        MCPToolset instance or None if creation fails
+    """
+    try:
+        from google.adk.tools.mcp_tool.mcp_toolset import MCPToolset
+        from google.adk.tools.mcp_tool.mcp_session_manager import (
+            SseConnectionParams,
+            StreamableHTTPConnectionParams,
+        )
+
+        # A stdio server is a local process; an HTTP one is wherever the URL points.
+        # Refuse anything that is not http(s) rather than handing an arbitrary
+        # scheme to the transport.
+        scheme = urlparse(url).scheme.lower()
+        if scheme not in ("http", "https"):
+            logger.error(
+                f"Skipping MCP server for agent '{agent_name}': "
+                f"url '{url}' is not http or https. "
+                f"The agent will respond without this MCP tool."
+            )
+            return None
+
+        params_cls = SseConnectionParams if transport == "sse" else StreamableHTTPConnectionParams
+        mcp_toolset = MCPToolset(
+            connection_params=params_cls(
+                url=url,
+                headers=headers or None,
+                timeout=float(connect_timeout),
+                sse_read_timeout=float(timeout),
+            ),
+        )
+
+        logger.info(
+            f"Created {transport} MCP toolset for {agent_name} at {url}"
+        )
+        return mcp_toolset
+
+    except ImportError as e:
+        logger.warning(f"MCP tools not available for agent {agent_name}: {e}")
+        return None
+    except Exception as e:
+        logger.error(f"Failed to create HTTP MCP toolset for agent {agent_name}: {e}")
+        return None
+
+
+def _parse_json_field(value: Any, field: str, server_name: str, agent_name: str) -> Optional[Any]:
+    """
+    Config fields arrive either already parsed or as a JSON string, depending on
+    whether they came from the database or the dashboard. Returns None when the
+    string is not valid JSON, having logged which field and which server.
+    """
+    if not isinstance(value, str):
+        return value
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        logger.error(
+            f"Invalid JSON in {field} for server '{server_name}' in agent '{agent_name}': {value}"
+        )
+        return None
+
+
 def create_mcp_tools_from_config(config: Dict[str, Any]) -> List[Any]:
     """
     Create MCP tools from agent configuration using both new multi-server format and legacy format.
@@ -140,43 +228,62 @@ def create_mcp_tools_from_config(config: Dict[str, Any]) -> List[Any]:
             
             for server_name, server_config in mcp_servers.items():
                 try:
-                    command = server_config.get('command')
-                    args_raw = server_config.get('args', [])
-                    env_raw = server_config.get('env', {})
-                    
-                    # Parse args if it's a JSON string
-                    if isinstance(args_raw, str):
-                        try:
-                            args = json.loads(args_raw)
-                        except json.JSONDecodeError:
-                            logger.error(f"Invalid JSON in args for server '{server_name}' in agent '{agent_name}': {args_raw}")
+                    timeout = server_config.get('timeout', 60)
+                    url = server_config.get('url')
+
+                    if url:
+                        # A url means a remote server we can reach directly, with no
+                        # subprocess in between.
+                        headers = _parse_json_field(
+                            server_config.get('headers', {}), 'headers', server_name, agent_name
+                        ) or {}
+                        # Configs in the wild spell the transport as either key.
+                        transport = (
+                            server_config.get('transport')
+                            or server_config.get('type')
+                            or 'streamable_http'
+                        )
+                        if server_config.get('command'):
+                            logger.warning(
+                                f"MCP server '{server_name}' in agent '{agent_name}' sets both "
+                                f"url and command; using url and ignoring command"
+                            )
+                        mcp_toolset = create_mcp_toolset_http(
+                            url,
+                            headers,
+                            f"{agent_name}_{server_name}",
+                            timeout=timeout,
+                            connect_timeout=server_config.get('connect_timeout', 5.0),
+                            transport=transport,
+                        )
+                    else:
+                        command = server_config.get('command')
+                        args = _parse_json_field(
+                            server_config.get('args', []), 'args', server_name, agent_name
+                        )
+                        if args is None:
                             continue
-                    else:
-                        args = args_raw
-                    
-                    # Parse env if it's a JSON string
-                    if isinstance(env_raw, str):
-                        try:
-                            env = json.loads(env_raw)
-                        except json.JSONDecodeError:
-                            logger.error(f"Invalid JSON in env for server '{server_name}' in agent '{agent_name}': {env_raw}")
-                            env = {}
-                    else:
-                        env = env_raw
-                    
-                    if command and args:
-                        timeout = server_config.get('timeout', 60)
+                        env = _parse_json_field(
+                            server_config.get('env', {}), 'env', server_name, agent_name
+                        ) or {}
+
+                        if not (command and args):
+                            logger.warning(
+                                f"Invalid MCP server configuration for '{server_name}' in agent "
+                                f"'{agent_name}': needs either a url, or a command and args"
+                            )
+                            continue
+
                         mcp_toolset = create_mcp_toolset_command(
                             command, args, env, f"{agent_name}_{server_name}", timeout=timeout
                         )
-                        if mcp_toolset:
-                            tools.append(mcp_toolset)
-                            logger.info(f"Created MCP toolset for server '{server_name}' in agent '{agent_name}'")
-                        else:
-                            logger.warning(f"Failed to create MCP toolset for server '{server_name}' in agent '{agent_name}'")
+
+                    if mcp_toolset:
+                        tools.append(mcp_toolset)
+                        logger.info(f"Created MCP toolset for server '{server_name}' in agent '{agent_name}'")
                     else:
-                        logger.warning(f"Invalid MCP server configuration for '{server_name}' in agent '{agent_name}': missing command or args")
-                        
+                        logger.warning(f"Failed to create MCP toolset for server '{server_name}' in agent '{agent_name}'")
+
                 except Exception as e:
                     logger.error(f"Failed to create MCP toolset for server '{server_name}' in agent '{agent_name}': {e}")
                     

--- a/templates/dashboard/modals/config_modals.html
+++ b/templates/dashboard/modals/config_modals.html
@@ -228,17 +228,19 @@
                 <textarea id="{{ id_prefix }}McpServersConfig" name="{{ id_prefix }}McpServersConfig" rows="10"
                     placeholder='{
   "mcpServers": {
-    "mate-chess-mcp": {
-      "command": "npx",
-      "args": ["mcp-remote", "https://your-mcp-server.example/mcp"]
+    "example-remote": {
+      "url": "https://your-mcp-server.example/mcp",
+      "headers": {"Authorization": "Bearer ${AUTH_TOKEN}"}
     }
   }
 }' class="w-full border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-blue-500 text-xs font-mono"></textarea>
                 <div id="{{ id_prefix }}McpServersConfigEditor"
                     style="display: none; height: 200px; border: 1px solid #d1d5db; border-radius: 0.25rem;"
                     class="mt-0.5"></div>
-                <p class="text-xs text-gray-500 dark:text-gray-400">Each server can define command, args, env, and
-                    headers. Use interpolation for secrets (e.g. <code>${AUTH_HEADER}</code>).</p>
+                <p class="text-xs text-gray-500 dark:text-gray-400">A server with a <code>url</code> is
+                    reached over HTTP; one with <code>command</code> and <code>args</code> runs as a local
+                    subprocess. Values are stored and sent literally, so a token pasted here is kept
+                    in the database as written.</p>
             </div>
             <div class="px-4 py-3 border-t border-gray-200 dark:border-gray-700 flex justify-end space-x-2">
                 <button type="button"

--- a/templates/dashboard/modals/config_modals.html
+++ b/templates/dashboard/modals/config_modals.html
@@ -239,8 +239,9 @@
                     class="mt-0.5"></div>
                 <p class="text-xs text-gray-500 dark:text-gray-400">A server with a <code>url</code> is
                     reached over HTTP; one with <code>command</code> and <code>args</code> runs as a local
-                    subprocess. Values are stored and sent literally, so a token pasted here is kept
-                    in the database as written.</p>
+                    subprocess. Write secrets as <code>${AUTH_TOKEN}</code> to read them from the server
+                    environment instead of storing them here; if the variable is unset, the server is
+                    skipped rather than called without it.</p>
             </div>
             <div class="px-4 py-3 border-t border-gray-200 dark:border-gray-700 flex justify-end space-x-2">
                 <button type="button"


### PR DESCRIPTION
MATE serves its own agents as HTTP MCP servers, but the client could only speak stdio. A remote server therefore had to be reached by spawning `npx mcp-remote` as a subprocess — Node on the host, a process per server, and a translation hop to talk a protocol MATE already implements on the other side.

Two commits, reviewable separately.

## 1. HTTP/SSE transport for the MCP client

A server entry is now HTTP when it carries a `url`, and stdio when it carries `command`/`args`. Streamable HTTP is the default transport, with `sse` selectable for older servers; `headers` carries auth.

ADK 2.3 already ships `StreamableHTTPConnectionParams` and `SseConnectionParams`, so this is wiring rather than protocol work.

Decisions worth a look:

- **`timeout` keeps the meaning it already has for stdio** — how long a slow tool may take — so it maps to the read timeout, not ADK's 5-second connect timeout. Otherwise every config that raised `timeout` to 300 for a slow tool would silently have started meaning something else. `connect_timeout` is separate.
- **A url that is not http or https is refused** rather than handed to the transport.
- **If an entry sets both forms, the url wins** and the command is ignored, with a warning — rather than silently spawning a subprocess nobody asked for.

The three config fields that may arrive parsed or as a JSON string were handling that inline; `headers` would have been a fourth copy, so the parsing moved into one helper.

## 2. `${VAR}` interpolation, and the deprecated class name

The MCP config modal has been telling users to write secrets as `${AUTH_HEADER}` while **no such substitution existed anywhere in the tree**. Anyone who followed the hint sent the literal thirteen-character string as their credential and got an authentication failure with nothing to explain it.

Any string value in a server entry — `headers`, `url`, `command`, `args`, `env` — may now reference the server environment as `${VAR}`, so credentials stay out of the `agents_config` row and out of config exports.

Judgement calls, flagged because they are choices rather than obvious:

- **An unset variable skips that server** and logs which names were missing. An empty substitution sends an unauthenticated request that may quietly succeed with reduced scope; leaving the placeholder sends `${VAR}` itself as the credential, which is the bug being fixed. Skipping is the only failure that is loud.
- **Set-but-empty is a real value, not a miss** — something deliberately set it.
- **Interpolation runs after JSON parsing**, not over raw config text, so a secret containing a quote cannot corrupt a field that arrived as a JSON string.

Only `${NAME}` is a placeholder; a bare `$HOME` is left alone.

Note recorded in the docs: interpolation reads the server's environment, so anyone who can edit an agent's MCP config can route an environment value into a URL they choose. That is the same trust level agent configuration already carries — an admin can enable `code_executor` — so it is not a new exposure, but it is now written down rather than implicit.

`MCPToolset` is also renamed to `McpToolset`. ADK 2.3 keeps the old name as a subclass that only warns and delegates, so this is behaviour-identical and silences the DeprecationWarning. Four remaining mentions are prose in comments in unrelated modules and are left alone.

## UI and docs

The dashboard's MCP config is a free JSON textarea, so it needed no new form — only its placeholder, which taught the `mcp-remote` workaround as the default example. `documents/MCP_SERVERS.md` gains a transport table, the HTTP field reference, and an interpolation section.

## Verification

**799 tests, OK.**

Each change was checked by reverting it and confirming the new tests fail:

| Reverted | Result |
|---|---|
| HTTP transport | 9 of 13 fail; the 4 that pass are the stdio regression guards |
| Interpolation | 8 of 10 fail; the 2 that pass assert literal config and bare `$NAME` are untouched |

The stdio path is covered by explicit regression tests — it is what every existing installation is configured with, and it is unchanged.

Not covered: no test talks to a real MCP server over the network. The self-referential end-to-end check — pointing MATE at its own `/agents/{name}/mcp` endpoint — is worth doing once against a running instance before this is relied on in production.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ToCUNy2SqwvfTq4a6xfSk1

---
_Generated by [Claude Code](https://claude.ai/code/session_01ToCUNy2SqwvfTq4a6xfSk1)_