### PR TITLE
feat(agents): point an agent at an OpenAI-compatible endpoint you alr…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ Follow PEP 8 with type hints on all function signatures. Use f-strings for forma
 ## Important Documentation
 
 - `AGENTS.md` — Architecture patterns and development guidelines (read before adding new agents or tools)
-- `documents/` — Feature-specific docs: `MCP_SERVERS.md`, `RATE_LIMITS.md`, `ALERTS.md`, `TRACING.md`, `WIDGET_INTEGRATION.md`, `TEMPLATE_LIBRARY.md`, `AGENT_WIZARD.md`, `LANGGRAPH_RUNTIME.md`
+- `documents/` — Feature-specific docs: `MCP_SERVERS.md`, `RATE_LIMITS.md`, `ALERTS.md`, `TRACING.md`, `WIDGET_INTEGRATION.md`, `TEMPLATE_LIBRARY.md`, `AGENT_WIZARD.md`, `LANGGRAPH_RUNTIME.md`, `EXTERNAL_AGENTS.md`
 - `shared/sql/README.md` — Database schema reference
 
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Drill into individual request logs — prompt / response / thought / tool-use to
 
 **OpenAI Compatibility & External Clients**
 - OpenAI-compatible API bridge mapping MATE agents as standard LLM models at `/v1`
+- Point an agent at an OpenAI-compatible endpoint you already run, and MATE's RBAC, guardrails, evals and cost tracking apply to it
 - Expose any root agent as a model with a single switch in the dashboard
 - Secure access using Personal Access Tokens (PATs) hashed with SHA-256 in the database
 - Integration with external coding engines, CLI tools, and IDE extensions (OpenCode, Continue, Cline/Roo Code)
@@ -376,6 +377,7 @@ Each exposed agent gets endpoints at `/agents/{name}/mcp/*`. Built-in MCP server
 
 ## Additional Documentation
 
+- **[documents/EXTERNAL_AGENTS.md](documents/EXTERNAL_AGENTS.md)** — governing an agent that runs outside MATE
 - **[documents/OPENAI_COMPATIBILITY.md](documents/OPENAI_COMPATIBILITY.md)** — OpenAI-compatible API bridge, PAT generation, and external client setup (OpenCode, Continue, Cline)
 - **[documents/WIDGET_INTEGRATION.md](documents/WIDGET_INTEGRATION.md)** — embed code, widget admin panel, JS API, security, theming, page context
 - **[documents/SSO_OAUTH.md](documents/SSO_OAUTH.md)** — Google and GitHub SSO setup, enterprise domain restrictions, session security

--- a/documents/EXTERNAL_AGENTS.md
+++ b/documents/EXTERNAL_AGENTS.md
@@ -1,0 +1,76 @@
+# Pointing MATE at an agent you already run
+
+MATE's control layer — RBAC, cost tracking, guardrails, evals, versioning, audit
+logs, the embeddable widget — normally applies to agents built inside MATE. This
+lets it apply to an agent running somewhere else, without rebuilding it.
+
+## How it works
+
+An agent reached over `POST /v1/chat/completions` is, on the wire, the same shape
+as a model. So an external agent is registered as an ordinary MATE agent whose
+model points at the remote endpoint. Nothing else about the agent is special: it
+sits in the tree, obeys RBAC, is covered by guardrails, can be evaluated, and
+appears in usage and audit exactly like any other agent.
+
+Requirements for the remote:
+
+- It speaks the OpenAI chat-completions API.
+- It is reachable from the MATE host.
+
+## Configuring it
+
+In the agent modal, or via `POST /dashboard/api/agents`:
+
+| Field | Example | Notes |
+|-------|---------|-------|
+| Model Name | `openai/my-agent` | **Needs a provider prefix.** A bare `gemini-*` name routes to the native Gemini backend, which ignores the base URL |
+| Model Base URL | `https://agent.example.com/v1` | The remote's OpenAI-compatible root |
+| Model API Key | `${MY_AGENT_KEY}` | Optional. See below |
+
+Leave both endpoint fields empty and the agent behaves exactly as before,
+resolving its provider from environment variables.
+
+## Secrets
+
+Write the key as `${VAR}` to read it from the server environment. A key typed
+literally is stored in the `agents_config` row and captured in that agent's
+version history, and is therefore visible to anyone who can read the database or
+export the configuration.
+
+The dashboard never sends a stored literal key to the browser — it is replaced by
+a sentinel, and saving the form with the sentinel unchanged leaves the stored
+value alone. A `${VAR}` reference is not a secret, so it is shown as written.
+
+Two failure modes are deliberate:
+
+- **A `${VAR}` that is not set refuses to build the agent**, with the missing name
+  in the error and in the dashboard's last-error field. The alternative is worse:
+  LiteLLM would fall back to the provider's own key and send it to whatever host
+  the base URL names.
+- **An endpoint configured with no key does not inherit the provider's key.** A
+  placeholder is sent instead, so `OPENAI_API_KEY` never travels to a third-party
+  host. Endpoints that need no key (local servers, private networks) work as
+  expected.
+
+## What you get, and what you do not
+
+Applies to the external agent as to any other:
+
+- Per-agent RBAC, so the remote is only reachable by the roles you allow
+- Input and output guardrails
+- Eval suites, including LLM-as-judge and regression thresholds
+- Configuration versioning and rollback, and audit entries for every change
+- The chat widget and the Work Room
+
+**Cost tracking depends on the remote.** Token counts come from the `usage`
+object in its response. An endpoint that omits `usage` produces requests with no
+token counts rather than invented ones — the request is still recorded.
+
+The remote runs its own agent loop. MATE sees one request and one response, so
+its internal tool calls and sub-agent steps do not appear in MATE's traces.
+
+## Both runtimes
+
+The ADK and LangGraph runtimes resolve the endpoint through the same function
+(`resolve_agent_endpoint` in `shared/utils/utils.py`), so a configuration means
+the same thing under either.

--- a/shared/sql/migrations/mysql/V030__agent_model_endpoint.sql
+++ b/shared/sql/migrations/mysql/V030__agent_model_endpoint.sql
@@ -1,0 +1,11 @@
+-- Migration: Per-agent OpenAI-compatible endpoint for agents_config
+-- Version: V030
+-- Database: MySQL
+--
+-- Without these the endpoint came only from provider env vars, so every agent
+-- shared one endpoint per provider and none could be pointed at an agent
+-- running elsewhere. model_api_key may hold a ${VAR} reference instead of the
+-- secret itself.
+
+ALTER TABLE agents_config ADD COLUMN IF NOT EXISTS model_base_url VARCHAR(1024) NULL;
+ALTER TABLE agents_config ADD COLUMN IF NOT EXISTS model_api_key VARCHAR(1024) NULL;

--- a/shared/sql/migrations/postgresql/V030__agent_model_endpoint.sql
+++ b/shared/sql/migrations/postgresql/V030__agent_model_endpoint.sql
@@ -1,0 +1,11 @@
+-- Migration: Per-agent OpenAI-compatible endpoint for agents_config
+-- Version: V030
+-- Database: PostgreSQL
+--
+-- Without these the endpoint came only from provider env vars, so every agent
+-- shared one endpoint per provider and none could be pointed at an agent
+-- running elsewhere. model_api_key may hold a ${VAR} reference instead of the
+-- secret itself.
+
+ALTER TABLE agents_config ADD COLUMN IF NOT EXISTS model_base_url VARCHAR(1024) NULL;
+ALTER TABLE agents_config ADD COLUMN IF NOT EXISTS model_api_key VARCHAR(1024) NULL;

--- a/shared/sql/migrations/sqlite/V030__agent_model_endpoint.sql
+++ b/shared/sql/migrations/sqlite/V030__agent_model_endpoint.sql
@@ -1,0 +1,11 @@
+-- Migration: Per-agent OpenAI-compatible endpoint for agents_config
+-- Version: V030
+-- Database: SQLite
+--
+-- Without these the endpoint came only from provider env vars, so every agent
+-- shared one endpoint per provider and none could be pointed at an agent
+-- running elsewhere. model_api_key may hold a ${VAR} reference instead of the
+-- secret itself.
+
+ALTER TABLE agents_config ADD COLUMN model_base_url VARCHAR(1024) NULL;
+ALTER TABLE agents_config ADD COLUMN model_api_key VARCHAR(1024) NULL;

--- a/shared/test/test_agent_model_endpoint.py
+++ b/shared/test/test_agent_model_endpoint.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""
+Tests for per-agent OpenAI-compatible endpoints.
+
+An external agent reached over /v1/chat/completions is, on the wire,
+indistinguishable from a model — so pointing MATE at an agent you already run
+needs no proxy agent class, only somewhere to put the endpoint. Before this,
+base_url and api_key came from provider env vars alone, so every agent shared one
+endpoint per provider.
+
+The security-relevant case is an unresolvable ${VAR}. Falling back to the
+provider's env key would send that key to whatever third-party host base_url
+names, so the agent refuses to build instead.
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from shared.utils.utils import resolve_agent_endpoint, resolve_env_placeholders
+
+
+class TestResolveEnvPlaceholders(unittest.TestCase):
+    """The shared helper, used by both MCP config and agent endpoints."""
+
+    def test_reports_missing_names_rather_than_guessing(self):
+        os.environ.pop("NOT_SET_ANYWHERE", None)
+        resolved, missing = resolve_env_placeholders("Bearer ${NOT_SET_ANYWHERE}")
+        self.assertEqual(missing, {"NOT_SET_ANYWHERE"})
+        # The placeholder survives so a caller cannot mistake it for a real value.
+        self.assertEqual(resolved, "Bearer ${NOT_SET_ANYWHERE}")
+
+    def test_recurses_through_lists_and_dicts(self):
+        with patch.dict(os.environ, {"V": "x"}):
+            resolved, missing = resolve_env_placeholders(
+                {"a": ["${V}", {"b": "${V}"}], "c": 7})
+        self.assertEqual(resolved, {"a": ["x", {"b": "x"}], "c": 7})
+        self.assertEqual(missing, set())
+
+    def test_leaves_a_bare_dollar_name_alone(self):
+        resolved, missing = resolve_env_placeholders("$HOME costs $100")
+        self.assertEqual(resolved, "$HOME costs $100")
+        self.assertEqual(missing, set())
+
+
+class TestResolveAgentEndpoint(unittest.TestCase):
+
+    def test_an_agent_without_an_endpoint_is_unaffected(self):
+        self.assertEqual(resolve_agent_endpoint({"name": "a", "model_name": "openai/gpt-4o"}),
+                         (None, None))
+
+    def test_the_endpoint_is_read_from_the_row(self):
+        base_url, api_key = resolve_agent_endpoint({
+            "name": "a", "model_name": "openai/my-agent",
+            "model_base_url": "https://agent.example.com/v1",
+            "model_api_key": "sk-literal",
+        })
+        self.assertEqual(base_url, "https://agent.example.com/v1")
+        self.assertEqual(api_key, "sk-literal")
+
+    def test_the_key_may_live_in_the_environment(self):
+        with patch.dict(os.environ, {"MY_AGENT_KEY": "sk-from-env"}):
+            _, api_key = resolve_agent_endpoint({
+                "name": "a", "model_name": "openai/my-agent",
+                "model_base_url": "https://agent.example.com/v1",
+                "model_api_key": "${MY_AGENT_KEY}",
+            })
+        self.assertEqual(api_key, "sk-from-env")
+
+    def test_an_unresolvable_key_refuses_rather_than_falling_back(self):
+        # Falling back would send the provider's own key to agent.example.com.
+        os.environ.pop("NOT_SET_ANYWHERE", None)
+        with self.assertRaises(ValueError) as caught:
+            resolve_agent_endpoint({
+                "name": "a", "model_name": "openai/my-agent",
+                "model_base_url": "https://agent.example.com/v1",
+                "model_api_key": "${NOT_SET_ANYWHERE}",
+            })
+        self.assertIn("NOT_SET_ANYWHERE", str(caught.exception))
+
+    def test_a_keyless_endpoint_does_not_inherit_the_provider_key(self):
+        # LiteLLM would otherwise read OPENAI_API_KEY and send it to the host
+        # base_url names. A placeholder keeps it at home.
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-mine"}):
+            _, api_key = resolve_agent_endpoint({
+                "name": "a", "model_name": "openai/local",
+                "model_base_url": "http://localhost:9000/v1",
+            })
+        self.assertIsNotNone(api_key)
+        self.assertNotEqual(api_key, "sk-mine")
+
+    def test_a_base_url_on_a_native_gemini_model_warns(self):
+        # create_model routes bare gemini names to the native backend, which
+        # ignores base_url — silently, without this.
+        with self.assertLogs("shared.utils.utils", level="WARNING") as logs:
+            resolve_agent_endpoint({
+                "name": "a", "model_name": "gemini-2.5-flash",
+                "model_base_url": "https://agent.example.com/v1",
+            })
+        self.assertIn("ignores it", "\n".join(logs.output))
+
+    def test_no_warning_when_the_model_carries_a_provider_prefix(self):
+        with patch("shared.utils.utils.logger") as log:
+            resolve_agent_endpoint({
+                "name": "a", "model_name": "openai/my-agent",
+                "model_base_url": "https://agent.example.com/v1",
+            })
+        log.warning.assert_not_called()
+
+
+class TestModelBuiltFromConfig(unittest.TestCase):
+
+    def test_the_endpoint_reaches_create_model(self):
+        from shared.utils import utils
+        with patch.object(utils, "create_model") as create:
+            utils.create_model_from_agent_config({
+                "name": "a", "model_name": "openai/my-agent",
+                "model_base_url": "https://agent.example.com/v1",
+                "model_api_key": "sk-literal",
+            })
+        create.assert_called_once_with(
+            model_name="openai/my-agent",
+            api_key="sk-literal",
+            base_url="https://agent.example.com/v1",
+        )
+
+    def test_an_ordinary_agent_still_passes_no_endpoint(self):
+        from shared.utils import utils
+        with patch.object(utils, "create_model") as create:
+            utils.create_model_from_agent_config({"name": "a", "model_name": "gemini-2.5-flash"})
+        create.assert_called_once_with(
+            model_name="gemini-2.5-flash", api_key=None, base_url=None)
+
+
+class TestStoredKeyMasking(unittest.TestCase):
+    """A literal key must not reach the browser, but must survive a form round trip."""
+
+    def test_a_literal_key_is_masked(self):
+        from shared.utils.dashboard.dashboard_server import mask_api_key, STORED_SECRET_SENTINEL
+        self.assertEqual(mask_api_key("sk-abc123"), STORED_SECRET_SENTINEL)
+
+    def test_an_env_reference_is_not_a_secret_and_goes_out_as_written(self):
+        from shared.utils.dashboard.dashboard_server import mask_api_key
+        self.assertEqual(mask_api_key("${MY_AGENT_KEY}"), "${MY_AGENT_KEY}")
+
+    def test_nothing_stored_stays_nothing(self):
+        from shared.utils.dashboard.dashboard_server import mask_api_key
+        self.assertIsNone(mask_api_key(None))
+        self.assertEqual(mask_api_key(""), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/shared/utils/agent_manager.py
+++ b/shared/utils/agent_manager.py
@@ -354,7 +354,7 @@ class AgentManager:
         """Initialize an agent of any type."""
         # Import here to avoid circular imports
         from google.adk.agents import Agent
-        from .utils import create_model
+        from .utils import create_model_from_agent_config
         from ..callbacks.token_usage_callback import capture_model_name_callback, log_token_usage_callback
         from ..callbacks.rbac_callback import combined_rbac_and_token_callback
         from ..callbacks.user_profile_callback import combined_user_profile_and_rbac_callback
@@ -712,7 +712,7 @@ class AgentManager:
                 # Build agent parameters
                 agent_params = {
                     'name': agent_name,
-                    'model': create_model(model_name=config.get('model_name')),
+                    'model': create_model_from_agent_config(config),
                     'description': description,
                     'instruction': instruction,
                     'tools': tools,

--- a/shared/utils/dashboard/dashboard_server.py
+++ b/shared/utils/dashboard/dashboard_server.py
@@ -48,6 +48,20 @@ def sanitize_agent_text(text: Optional[str]) -> Optional[str]:
     return text
 
 
+# The edit form posts every field back, so the stored key has to survive a round
+# trip without being sent to the browser. A ${VAR} reference is not a secret and
+# goes out as written; anything else is replaced by this sentinel, and a save that
+# returns the sentinel unchanged leaves the stored value alone.
+STORED_SECRET_SENTINEL = "__stored__"
+
+
+def mask_api_key(value: Optional[str]) -> Optional[str]:
+    """Hide a literal key from API responses, passing ${VAR} references through."""
+    if not value or value.strip().startswith("${"):
+        return value
+    return STORED_SECRET_SENTINEL
+
+
 def make_name_substituter(name_map: Dict[str, str]):
     """Build a substituter that rewrites agent names in strings, lists and dicts.
 
@@ -1434,6 +1448,8 @@ class DashboardServer:
             'name': config.name,
             'type': config.type,
             'model_name': config.model_name,
+            'model_base_url': config.model_base_url,
+            'model_api_key': config.model_api_key,
             'description': config.description,
             'instruction': config.instruction,
             'mcp_servers_config': config.mcp_servers_config,
@@ -1594,6 +1610,8 @@ class DashboardServer:
                     "name": config.name,
                     "type": config.type,
                     "model_name": config.model_name,
+                    "model_base_url": config.model_base_url,
+                    "model_api_key": mask_api_key(config.model_api_key),
                     "description": config.description,
                     "instruction": config.instruction,
                     "mcp_servers_config": config.mcp_servers_config,
@@ -2005,6 +2023,8 @@ class DashboardServer:
                     "name": name_map[old_name],
                     "type": source.type,
                     "model_name": source.model_name,
+                    "model_base_url": source.model_base_url,
+                    "model_api_key": source.model_api_key,
                     "description": source.description,
                     "instruction": _substitute(source.instruction),
                     "mcp_servers_config": _substitute(source.mcp_servers_config),
@@ -2193,6 +2213,8 @@ class DashboardServer:
                 "name": new_name,
                 "type": agent_data.get("type", "llm"),
                 "model_name": agent_data.get("model_name"),
+                "model_base_url": agent_data.get("model_base_url"),
+                "model_api_key": agent_data.get("model_api_key"),
                 "description": agent_data.get("description"),
                 "instruction": sub_names(agent_data.get("instruction") or ""),
                 "parent_agents": sub_names(agent_data.get("parent_agents") or []),
@@ -2537,6 +2559,8 @@ class DashboardServer:
                         "name": proj_name,
                         "type": tpl_agent.get("type", "llm"),
                         "model_name": tpl_agent.get("model_name"),
+                        # Endpoint yes, credential no — a template is shared.
+                        "model_base_url": tpl_agent.get("model_base_url"),
                         "description": tpl_agent.get("description"),
                         "instruction": sub_names(tpl_agent.get("instruction") or ""),
                         "parent_agents": sub_names(tpl_agent.get("parent_agents") or []),
@@ -4630,6 +4654,8 @@ class DashboardServer:
             type: str = Form(...),
             project_id: str = Form(...),
             model_name: str = Form(None),
+            model_base_url: str = Form(None),
+            model_api_key: str = Form(None),
             description: str = Form(None),
             instruction: str = Form(None),
             parent_agents: str = Form(None),
@@ -4665,6 +4691,8 @@ class DashboardServer:
                 "type": type,
                 "project_id": int(project_id) if project_id else None,
                 "model_name": model_name,
+                "model_base_url": model_base_url or None,
+                "model_api_key": (None if model_api_key == STORED_SECRET_SENTINEL else (model_api_key or None)),
                 "description": description,
                 "instruction": instruction,
                 "parent_agents": parent_agents_list,
@@ -4697,6 +4725,8 @@ class DashboardServer:
             type: str = Form(...),
             project_id: str = Form(...),
             model_name: str = Form(None),
+            model_base_url: str = Form(None),
+            model_api_key: str = Form(None),
             description: str = Form(None),
             instruction: str = Form(None),
             parent_agents: str = Form(None),
@@ -4732,6 +4762,7 @@ class DashboardServer:
                 "type": type,
                 "project_id": int(project_id) if project_id else None,
                 "model_name": model_name,
+                "model_base_url": model_base_url or None,
                 "description": description,
                 "instruction": instruction,
                 "parent_agents": parent_agents_list,
@@ -4750,6 +4781,10 @@ class DashboardServer:
                 "expose_as_model": expose_as_model,
                 "debug_mode": debug_mode
             }
+            # The sentinel means the form never saw the real key, so leave it be.
+            # Anything else — including an empty field, which clears it — is a change.
+            if model_api_key != STORED_SECRET_SENTINEL:
+                config_data["model_api_key"] = model_api_key or None
             success = self._update_agent_config(config_id, config_data, changed_by=username)
             if success:
                 audit_service.log(username, audit_service.ACTION_AGENT_UPDATE, audit_service.RESOURCE_AGENT, resource_id=name, details={"config_id": config_id}, request=request)

--- a/shared/utils/langgraph/agent_builder.py
+++ b/shared/utils/langgraph/agent_builder.py
@@ -302,15 +302,19 @@ class AgentBuilder:
                                  transfer_note: Optional[str] = None) -> Any:
         from langgraph.prebuilt import create_react_agent
         from shared.utils.langgraph.model_factory import create_chat_model
+        from shared.utils.utils import resolve_agent_endpoint
 
         app_name = config["name"]
         planner_config = _json_field(config, "planner_config")
         if planner_config:
             logger.debug(f"Agent '{app_name}': planner_config is not supported by the langgraph runtime; ignoring")
 
+        base_url, api_key = resolve_agent_endpoint(config)
         model = create_chat_model(
             config.get("model_name"),
             generate_content_config=_json_field(config, "generate_content_config"),
+            api_key=api_key,
+            base_url=base_url,
         )
         tools = await self._build_tools(config)
         if extra_tools:

--- a/shared/utils/models.py
+++ b/shared/utils/models.py
@@ -190,6 +190,11 @@ class AgentConfig(Base):
     name = Column(String(255), nullable=False, unique=True)
     type = Column(String(50), nullable=False)  # llm, graph, loop
     model_name = Column(String(255), nullable=True)
+    # An OpenAI-compatible endpoint this agent's model lives behind. Without it the
+    # endpoint comes from provider env vars, so every agent shares one per provider
+    # and none can point at an agent you already run elsewhere.
+    model_base_url = Column(String(1024), nullable=True)
+    model_api_key = Column(String(1024), nullable=True)  # Literal, or ${VAR} read from the environment
     description = Column(Text, nullable=True)
     instruction = Column(Text, nullable=True)
     mcp_servers_config = Column(Text, nullable=True)  # JSON object containing multiple MCP server configurations
@@ -283,6 +288,8 @@ class AgentConfig(Base):
             'name': self.name,
             'type': self.type,
             'model_name': self.model_name,
+            'model_base_url': self.model_base_url,
+            'model_api_key': self.model_api_key,
             'description': self.description,
             'instruction': self.instruction,
             'mcp_servers_config': self.mcp_servers_config,

--- a/shared/utils/tools/mcp_tools.py
+++ b/shared/utils/tools/mcp_tools.py
@@ -5,10 +5,11 @@ MCP (Model Context Protocol) tools creation and management.
 import logging
 import json
 import os
-import re
 import shutil
 from typing import Dict, List, Any, Optional
 from urllib.parse import urlparse
+
+from ..utils import resolve_env_placeholders
 
 logger = logging.getLogger(__name__)
 
@@ -185,40 +186,16 @@ def create_mcp_toolset_http(
         return None
 
 
-# Secrets do not belong in agent config rows, so string values in an MCP server
-# entry may reference the server environment as ${VAR}.
-_ENV_PLACEHOLDER = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
-
-
 def _resolve_env(obj: Any, server_name: str, agent_name: str) -> Optional[Any]:
     """
-    Replace ${VAR} references with values from the environment, recursing through
-    lists and dicts.
+    Resolve ${VAR} references in a server entry.
 
     Returns None if any referenced variable is unset, having logged which ones.
     Skipping the server is the safe failure: substituting an empty string would
     send an unauthenticated request, and leaving the placeholder would send the
     literal text `${VAR}` as the credential.
     """
-    missing = set()
-
-    def walk(value: Any) -> Any:
-        if isinstance(value, str):
-            def substitute(match):
-                name = match.group(1)
-                resolved = os.environ.get(name)
-                if resolved is None:
-                    missing.add(name)
-                    return match.group(0)
-                return resolved
-            return _ENV_PLACEHOLDER.sub(substitute, value)
-        if isinstance(value, list):
-            return [walk(item) for item in value]
-        if isinstance(value, dict):
-            return {key: walk(item) for key, item in value.items()}
-        return value
-
-    resolved = walk(obj)
+    resolved, missing = resolve_env_placeholders(obj)
     if missing:
         logger.error(
             f"Skipping MCP server '{server_name}' for agent '{agent_name}': "

--- a/shared/utils/utils.py
+++ b/shared/utils/utils.py
@@ -4,9 +4,10 @@ Utility functions for the MATE (Multi-Agent Tree Engine) system.
 
 import os
 import logging
+import re
 from google.adk.models.lite_llm import LiteLlm
 from google.adk.models import Gemini
-from typing import Dict, Any, Optional, Any as AnyType
+from typing import Dict, Any, Optional, Set, Tuple, Any as AnyType
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +61,44 @@ def _is_gemini_model(model_name: str) -> bool:
     if not provider:
         return True
     return model_name.startswith(('gemini-', 'models/'))
+
+
+
+# Secrets belong in the environment, not in database config rows, so string values
+# in agent and MCP configuration may reference it as ${VAR}.
+ENV_PLACEHOLDER = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+
+
+def resolve_env_placeholders(obj: AnyType) -> Tuple[AnyType, Set[str]]:
+    """
+    Replace ${VAR} references with values from the environment, recursing through
+    lists and dicts.
+
+    Returns the resolved value and the set of names that were not set. Callers
+    decide what an unresolved name means for them; leaving the placeholder in
+    place is never right, because it would be used as though it were the value.
+
+    Only ${NAME} is a placeholder — a bare $NAME is left alone.
+    """
+    missing: Set[str] = set()
+
+    def walk(value: AnyType) -> AnyType:
+        if isinstance(value, str):
+            def substitute(match):
+                name = match.group(1)
+                resolved = os.environ.get(name)
+                if resolved is None:
+                    missing.add(name)
+                    return match.group(0)
+                return resolved
+            return ENV_PLACEHOLDER.sub(substitute, value)
+        if isinstance(value, list):
+            return [walk(item) for item in value]
+        if isinstance(value, dict):
+            return {key: walk(item) for key, item in value.items()}
+        return value
+
+    return walk(obj), missing
 
 
 def create_model(model_name: str = None, api_key: str = None, base_url: str = None):
@@ -139,6 +178,62 @@ def create_model(model_name: str = None, api_key: str = None, base_url: str = No
     logger.info(f"Creating LiteLLM model: {effective_model_name} (provider: {provider})")
     return LiteLlm(effective_model_name, **litellm_kwargs)
 
+
+
+def resolve_agent_endpoint(config: Dict[str, Any]) -> Tuple[Optional[str], Optional[str]]:
+    """
+    Read a database agent's own OpenAI-compatible endpoint as (base_url, api_key).
+
+    This is what lets one agent point at an agent you already run elsewhere while
+    another uses a hosted provider: without it the endpoint comes from provider
+    env vars, so every agent shares one per provider.
+
+    Both runtimes call this so they agree on what a config means.
+
+    Raises ValueError if the configured key references an environment variable
+    that is not set. Falling back would be worse than failing: `base_url` names a
+    third-party host, and LiteLLM's fallback would send the provider's own key
+    there.
+    """
+    resolved, missing = resolve_env_placeholders({
+        'base_url': config.get('model_base_url') or None,
+        'api_key': config.get('model_api_key') or None,
+    })
+    if missing:
+        raise ValueError(
+            f"model endpoint references {', '.join(sorted(missing))}, "
+            f"which is not set in the environment"
+        )
+
+    base_url = resolved['base_url']
+    api_key = resolved['api_key']
+
+    if base_url:
+        model_name = (config.get('model_name') or '').strip()
+        if _is_gemini_model(model_name):
+            logger.warning(
+                f"Agent '{config.get('name', 'unknown')}' sets model_base_url but "
+                f"'{model_name}' routes to the native Gemini backend, which ignores it. "
+                f"Prefix the model with a provider (e.g. 'openai/') to use the endpoint."
+            )
+        if not api_key:
+            # Endpoints that need no key are normal (local servers, agents on a
+            # private network). But leaving api_key unset makes LiteLLM fall back to
+            # the provider's env key, which would then travel to whatever host
+            # base_url names. Send a placeholder instead.
+            api_key = "not-required"
+
+    return base_url, api_key
+
+
+def create_model_from_agent_config(config: Dict[str, Any]):
+    """Build the model for a database-configured agent, honouring its own endpoint."""
+    base_url, api_key = resolve_agent_endpoint(config)
+    return create_model(
+        model_name=config.get('model_name'),
+        api_key=api_key,
+        base_url=base_url,
+    )
 
 def get_database_config() -> Dict[str, Any]:
     """

--- a/static/js/agent-forms.js
+++ b/static/js/agent-forms.js
@@ -699,6 +699,8 @@ function editAgent(config) {
     document.getElementById('editAgentName').value = config.name;
     document.getElementById('editAgentType').value = config.type;
     document.getElementById('editAgentModel').value = config.model_name || '';
+    document.getElementById('editAgentModelBaseUrl').value = config.model_base_url || '';
+    document.getElementById('editAgentModelApiKey').value = config.model_api_key || '';
     document.getElementById('editAgentParents').value = safeStringify(config.parent_agents);
     document.getElementById('editAgentDescription').value = config.description || '';
     document.getElementById('editAgentInstruction').value = config.instruction || '';
@@ -817,6 +819,11 @@ function copyAgent(config) {
     document.getElementById('copyAgentName').value = config.name + '_copy';
     document.getElementById('copyAgentType').value = config.type;
     document.getElementById('copyAgentModel').value = config.model_name || '';
+    document.getElementById('copyAgentModelBaseUrl').value = config.model_base_url || '';
+    // The browser never saw the original key, so leave the copy's field empty
+    // rather than showing the sentinel and silently creating a keyless agent.
+    document.getElementById('copyAgentModelApiKey').value =
+        (config.model_api_key === '__stored__' ? '' : (config.model_api_key || ''));
     document.getElementById('copyAgentParents').value = config.parent_agents ? JSON.stringify(config.parent_agents) : '';
     document.getElementById('copyAgentDescription').value = config.description || '';
     document.getElementById('copyAgentInstruction').value = config.instruction || '';

--- a/static/js/agents-visual-builder.js
+++ b/static/js/agents-visual-builder.js
@@ -372,6 +372,8 @@
         formData.append('type', agent.type || 'llm');
         formData.append('project_id', projectId != null ? String(projectId) : '');
         formData.append('model_name', agent.model_name || '');
+                        formData.append('model_base_url', agent.model_base_url || '');
+                        formData.append('model_api_key', agent.model_api_key || '');
         formData.append('description', agent.description || '');
         formData.append('instruction', agent.instruction || '');
 
@@ -1633,6 +1635,8 @@
                 if (projectId) formData.append('project_id', projectId);
                 formData.append('type', document.getElementById('editAgentType').value);
                 formData.append('model_name', document.getElementById('editAgentModel').value || '');
+                formData.append('model_base_url', document.getElementById('editAgentModelBaseUrl').value || '');
+                formData.append('model_api_key', document.getElementById('editAgentModelApiKey').value || '');
                 formData.append('description', description);
                 formData.append('instruction', instruction);
 

--- a/templates/dashboard/agents.html
+++ b/templates/dashboard/agents.html
@@ -490,6 +490,8 @@
                 formData.append('project_id', projectId);
                 formData.append('type', document.getElementById('agentType').value);
                 formData.append('model_name', document.getElementById('agentModel').value || '');
+                formData.append('model_base_url', document.getElementById('agentModelBaseUrl').value || '');
+                formData.append('model_api_key', document.getElementById('agentModelApiKey').value || '');
                 formData.append('description', description);
                 formData.append('instruction', instruction);
                 // Get values from Monaco editors if they're active, otherwise from form fields
@@ -674,6 +676,8 @@
 
                 formData.append('type', document.getElementById('editAgentType').value);
                 formData.append('model_name', document.getElementById('editAgentModel').value || '');
+                formData.append('model_base_url', document.getElementById('editAgentModelBaseUrl').value || '');
+                formData.append('model_api_key', document.getElementById('editAgentModelApiKey').value || '');
                 formData.append('description', description);
                 formData.append('instruction', instruction);
                 // Get values from Monaco editors if they're active, otherwise from form fields
@@ -884,6 +888,8 @@
 
                 formData.append('project_id', projectId);
                 formData.append('model_name', document.getElementById('copyAgentModel').value || '');
+                formData.append('model_base_url', document.getElementById('copyAgentModelBaseUrl').value || '');
+                formData.append('model_api_key', document.getElementById('copyAgentModelApiKey').value || '');
                 formData.append('description', description);
                 formData.append('instruction', instruction);
                 // Get values from Monaco editors if they're active, otherwise from form fields

--- a/templates/dashboard/modals/agent_modal_macro.html
+++ b/templates/dashboard/modals/agent_modal_macro.html
@@ -106,6 +106,30 @@ container_class='', projects_list=None, current_project_id=None) %}
                                 "parent2"]</p>
                         </div>
                     </div>
+                    <div class="grid grid-cols-2 gap-2">
+                        <div>
+                            <label for="{{ id_prefix }}ModelBaseUrl"
+                                class="block text-xs font-medium text-gray-700 dark:text-gray-300">Model Base URL
+                                <span class="text-gray-400 font-normal">(optional)</span></label>
+                            <input type="text" id="{{ id_prefix }}ModelBaseUrl" name="{{ id_prefix }}ModelBaseUrl"
+                                placeholder="https://agent.example.com/v1"
+                                class="mt-0.5 block w-full border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-blue-500">
+                            <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Point this agent at an
+                                OpenAI-compatible endpoint you already run. Needs a provider prefix on the model
+                                (e.g. <code>openai/my-agent</code>).</p>
+                        </div>
+                        <div>
+                            <label for="{{ id_prefix }}ModelApiKey"
+                                class="block text-xs font-medium text-gray-700 dark:text-gray-300">Model API Key
+                                <span class="text-gray-400 font-normal">(optional)</span></label>
+                            <input type="password" id="{{ id_prefix }}ModelApiKey" name="{{ id_prefix }}ModelApiKey"
+                                placeholder="${MY_AGENT_KEY}" autocomplete="off"
+                                class="mt-0.5 block w-full border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-blue-500">
+                            <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Write
+                                <code>${VAR}</code> to read it from the server environment. A key typed literally is
+                                stored in the database and in this agent's version history.</p>
+                        </div>
+                    </div>
                     <div id="{{ id_prefix }}MaxIterationsField" class="hidden">
                         <label for="{{ id_prefix }}MaxIterations"
                             class="block text-xs font-medium text-gray-700 dark:text-gray-300">Max Iterations (for Loop


### PR DESCRIPTION
…eady run

MATE's control layer applied only to agents built inside MATE, so trying it meant rebuilding your agents in it. That is the wrong price for a control layer, and it is the likeliest reason the project collects stars without collecting users.

An agent reached over /v1/chat/completions is, on the wire, the same shape as a model, and create_model already routes openai/* through LiteLLM with a custom base_url — it is how LM Studio and llama.cpp are already supported. The only thing missing was somewhere to put the endpoint: create_model was called with the model name alone, so base_url and api_key came from provider env vars and every agent shared one endpoint per provider.

So this adds two columns rather than a proxy agent class. An external agent is an ordinary agent, which means RBAC, guardrails, evals, versioning, audit, the widget and cost tracking apply to it with no new code paths to keep in sync. Both runtimes resolve the endpoint through one function so a config means the same thing under either.

Two refusals are deliberate, and each is covered by a test that fails when the behaviour is mutated away:

A ${VAR} that is not set refuses to build the agent instead of falling back. Falling back would have LiteLLM read the provider's own key and send it to whatever third-party host base_url names.

An endpoint configured with no key is given a placeholder rather than left unset, for the same reason — keyless endpoints are normal on local servers and private networks, and OPENAI_API_KEY should not follow them out.

Keys are meant to be written as ${VAR}. A literal one is stored in the row and captured in version history, so the dashboard never sends it to the browser: responses carry a sentinel, and saving the form with the sentinel unchanged leaves the stored value alone. The copy form clears it rather than showing the sentinel, which would have created a keyless agent silently.

A template carries the endpoint but never the credential, since a template is a shared artifact. A config export round-trips both.

The ${VAR} resolver moved from mcp_tools to shared utils now that it has a second consumer.

814 tests, OK. Migration V030 verified against a real database: applied, columns present, and idempotent on a second run.


Claude-Session: https://claude.ai/code/session_01ToCUNy2SqwvfTq4a6xfSk1