### PR TITLE
Update README demo links and clarify setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,13 @@ Without a control layer, every one of those is a code change, a commit, and a re
 
 ## Try it without installing anything
 
-A live MATE instance runs at **[ai.antonijevic.rs](https://ai.antonijevic.rs)**.
+These run on a live MATE instance. No signup, no install.
 
-- **[Play the murder mystery demo](https://ai.antonijevic.rs/static/mystery-demo.html)** — a multi-agent game running on MATE. No signup: you question suspects, and a wrong accusation costs you
-- **[Build an agent in the browser](https://ai.antonijevic.rs/static/wizard-demo.html)** — the embeddable wizard provisions a working agent and lets you chat with it
+- **[Play the murder mystery demo](https://ai.antonijevic.rs/static/mystery-demo.html?key=wk_sQgptSKpw21XGHAEdcfLA9RykUDcDPYBt8uQjG-eK-g&lang=en)** — a multi-agent game running on MATE. No signup: you question suspects, and a wrong accusation costs you
+- **[Build an agent in the browser](https://ai.antonijevic.rs/static/wizard-demo.html)** — the embeddable wizard provisions a working agent and lets you chat with it (interface in Serbian)
 
-Everything below runs the same way on your own machine.
+The dashboard behind them needs an account — everything below sets up your own
+instance, which behaves the same way.
 
 ---
 


### PR DESCRIPTION
## Summary
Updated the README to improve clarity around the live demo experience and setup flow. Added API key parameter to the murder mystery demo link and clarified that the dashboard requires an account while the demos run without signup.

## Changes
- Rewrote the introductory sentence to emphasize "no signup, no install" for the live demos
- Added `key` and `lang` query parameters to the murder mystery demo link to enable the demo to run
- Added note that the wizard demo interface is in Serbian
- Clarified the relationship between the live demos and self-hosted setup: demos are public-facing, while the dashboard behind them requires authentication
- Improved the transition text to better explain that self-hosted instances behave the same way as the live demos

## Details
The changes make it clearer for new users that they can try MATE immediately via the live demos without any setup, while also setting proper expectations that accessing the full dashboard requires creating an account on a self-hosted instance.

https://claude.ai/code/session_01ToCUNy2SqwvfTq4a6xfSk1