### PR TITLE
v1.2.0: external agents, MCP over HTTP, secrets, and AI Act Art. 50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to MATE (Multi-Agent Tree Engine) will be documented in this
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-09-02
+
+MATE's control layer no longer requires that you built your agents in MATE, and
+EU AI Act Art. 50 obligations — which applied from 2 August 2026 — are now met by
+default on public chat surfaces.
+
+### Added
+
+- **External agents** - an agent can point at an OpenAI-compatible endpoint you already run, via `model_base_url` and `model_api_key` on the agent row. RBAC, guardrails, evals, config versioning, audit, cost tracking and the widget then apply to it like any other agent, with no new runtime paths. Both the ADK and LangGraph runtimes resolve the endpoint through the same function. See `documents/EXTERNAL_AGENTS.md`
+- **MCP over HTTP** - an external MCP server entry with a `url` is reached directly over streamable HTTP (or `sse` for older servers), instead of spawning `npx mcp-remote` as a subprocess. `command`/`args` stdio servers are unchanged. See `documents/MCP_SERVERS.md`
+- **`${VAR}` secrets** - any string in an MCP server entry, and an agent's endpoint key, may reference the server environment as `${VAR}`, keeping credentials out of the database and out of config exports. An unset variable skips the server or refuses to build the agent rather than sending the placeholder as a credential
+- **AI disclosure (Art. 50)** - the widget and standalone builds tell people they are talking to an AI. Wording is per-agent and translatable; there is no on/off switch, only a waiver field that hides the notice and records why, so the decision and its justification cannot come apart. Setting or clearing a waiver writes its own audit entry. See `documents/AI_ACT.md`
+- **Marking of generated images (Art. 50(2))** - generated PNGs carry an XMP packet declaring the IPTC digital source type `trainedAlgorithmicMedia`, written before the artifact is saved so every copy carries it. All three image generation paths mark
+- **`documents/AI_ACT.md`** - what applies when, and what MATE does and does not do about it
+- **Integration test against a live endpoint** - a stub OpenAI-compatible server on localhost proves the configured host, credential and `usage` object actually cross the wire. Streaming needed no translation layer; the test asserts that rather than assuming it
+
+### Changed
+
+- **`MCPToolset` renamed to `McpToolset`** - ADK 2.3 keeps the old name as a subclass that only warns and delegates, so this is behaviour-identical and silences the DeprecationWarning
+- **Compliance wording corrected** - `audit_service` described itself as "for EU AI Act compliance" and the README called the audit log "EU AI Act retention-aware". An append-only log is *evidence toward* Art. 12 record-keeping; compliance is a property of a deployed system and its operator, not of a log
+
+### Fixed
+
+- **README demo links** - the murder mystery link was published without its widget key, so the page rendered with nothing to interact with, and defaulted to Serbian. The section headline pointed at the site root, which redirects to an authenticated dashboard, so a visitor arriving from GitHub met a login form
+
+### Security
+
+- **A provider key no longer follows an agent to a third-party host.** An agent with a custom `model_base_url` and no key of its own is given a placeholder rather than left to LiteLLM's fallback, which would have read `OPENAI_API_KEY` and sent it to whatever that URL names
+- **An unresolvable `${VAR}` refuses to build the agent** instead of falling back, for the same reason
+- **Stored endpoint keys never reach the browser** - API responses carry a sentinel, and saving a form with the sentinel unchanged leaves the stored value alone. A `${VAR}` reference is not a secret and is shown as written. Templates carry an endpoint but never a credential
+
 ## [1.1.0] - 2026-09-02
 
 Everything shipped since 1.0.9. Highlights: a second agent runtime (LangGraph), an

--- a/documents/reddit/v1.2.0-external-agents-and-ai-act.md
+++ b/documents/reddit/v1.2.0-external-agents-and-ai-act.md
@@ -1,0 +1,42 @@
+# MATE v1.2.0 — Reddit announcement
+
+Target: r/agentdevelopmentkit (primary), r/mate_agents. Trim the ADK-specific
+framing for a general subreddit.
+
+---
+
+**Title:** MATE v1.2.0 — governance for agents you didn't build in MATE
+
+---
+
+MATE is an open-source control layer for agents: RBAC, cost tracking, guardrails,
+eval suites with regression thresholds, config versioning, audit logs, and an
+embeddable chat widget. Runs on Google ADK or LangGraph, same agents either way.
+
+Until now it only governed agents you built *inside* MATE, which is a bad trade —
+nobody wants to rebuild working agents to get a dashboard.
+
+**v1.2.0 removes that.** An agent can now point at any OpenAI-compatible endpoint
+you already run. It becomes an ordinary MATE agent, so RBAC, guardrails, evals,
+versioning, audit and cost tracking apply to it with no new code paths. Two
+fields on the agent, no proxy layer.
+
+Also in this release:
+
+- **MCP over HTTP.** External MCP servers with a `url` are reached directly, instead of spawning `npx mcp-remote` as a subprocess. stdio servers work as before.
+- **`${VAR}` secrets** in MCP and endpoint config, read from the server environment so credentials stay out of the database and out of config exports.
+- **EU AI Act Art. 50 support.** The widget now tells people they're talking to an AI, by default. There's no on/off switch — only a waiver field that hides the notice and records why, so the decision and its justification can't come apart. Generated images carry the IPTC `trainedAlgorithmicMedia` marker ahead of the 2 December 2026 deadline.
+
+To be clear about the last one: this doesn't make anyone compliant. Obligations
+sit with the provider or deployer of a system, not with the framework. What it
+does is make the default point the right way and leave a record when someone
+changes it.
+
+Try it without installing anything — a multi-agent murder mystery running on
+MATE, no signup:
+https://ai.antonijevic.rs/static/mystery-demo.html?key=wk_sQgptSKpw21XGHAEdcfLA9RykUDcDPYBt8uQjG-eK-g&lang=en
+
+Repo: https://github.com/antiv/mate (Apache-2.0)
+
+Happy to answer questions, and genuinely interested in whether the external-agent
+path works against whatever you're running — that's the part I most want broken.


### PR DESCRIPTION
## Summary

Release v1.2.0 adds support for external agents (pointing at any OpenAI-compatible endpoint), MCP over HTTP, environment variable secrets in config, and EU AI Act Article 50 compliance features (AI disclosure and generated image marking).

## Changes

- **External agents** — agents can now point to an OpenAI-compatible endpoint via `model_base_url` and `model_api_key`, applying RBAC, guardrails, evals, versioning, audit, and cost tracking without requiring agents to be built in MATE
- **MCP over HTTP** — external MCP servers with a `url` are reached directly over HTTP/SSE instead of spawning `npx mcp-remote` as a subprocess; stdio servers unchanged
- **`${VAR}` secrets** — MCP server entries and agent endpoint keys can reference server environment variables, keeping credentials out of the database and config exports; unset variables skip the server or refuse to build the agent
- **AI disclosure (Art. 50)** — the widget tells users they are talking to an AI by default; no on/off switch, only a waiver field that records why the notice was hidden, preventing decision and justification from separating
- **Generated image marking (Art. 50(2))** — PNGs carry an XMP packet with IPTC `trainedAlgorithmicMedia` marker ahead of the 2 December 2026 deadline
- **`MCPToolset` renamed to `McpToolset`** — ADK 2.3 keeps the old name as a deprecated subclass for backward compatibility
- **Security hardening** — provider keys no longer follow external agents to third-party hosts; unresolvable `${VAR}` references refuse to build; stored endpoint keys never reach the browser
- **Documentation** — added `documents/AI_ACT.md` explaining what applies when and what MATE does and does not do about compliance
- **Integration test** — new test against a live OpenAI-compatible endpoint proves configured host, credential, and usage object cross the wire correctly

## Notes

The AI Act features are defaults that point the right way; they do not make anyone compliant. Compliance obligations sit with the provider or deployer of a system, not the framework. The audit trail and waiver mechanism ensure decisions and their justifications are recorded and cannot come apart.

The external agent path is the primary focus for feedback — testing against whatever endpoint you're running is most valuable.

https://claude.ai/code/session_01ToCUNy2SqwvfTq4a6xfSk1