### PR TITLE
ci: open a discussion with each release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  discussions: write
 
 jobs:
   release:
@@ -39,3 +40,10 @@ jobs:
           gh release create "$GITHUB_REF_NAME" \
             --title "$GITHUB_REF_NAME" \
             --notes-file release_notes.md
+
+          # Open an Announcements thread so a release has somewhere to be replied
+          # to instead of being a one-way changelog post. Deliberately a separate,
+          # non-fatal step: a renamed or missing category should not fail a release
+          # that has already published correctly.
+          gh release edit "$GITHUB_REF_NAME" --discussion-category "Announcements" \
+            || echo "::warning::Could not open a release discussion. Check that an 'Announcements' category exists. The release itself is published."


### PR DESCRIPTION
A release is a one-way post: notes go out, and there is nowhere for anyone to say anything back. Discussions were enabled on the repository but the release that just shipped had no thread attached, so replying meant opening an issue.

Each release now opens an Announcements thread. Announcements rather than General because only maintainers can start threads there, which suits a release, while anyone can still reply.

Deliberately a separate step from the release itself, and non-fatal. Passing --discussion-category to `gh release create` would tie the two together, and a renamed or missing category would then fail a release whose notes were already correct. Publishing is the job; the thread is the nicety. A failure here logs a warning naming the likely cause and leaves the release standing.


Claude-Session: https://claude.ai/code/session_01ToCUNy2SqwvfTq4a6xfSk1